### PR TITLE
Add support for sidecar containers

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -27,6 +27,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
+        {{- if .Values.sidecarContainers -}}
+        {{- toYaml .Values.sidecarContainers | trim | nindent 8 }}
+        {{- end}}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/values.yaml
+++ b/values.yaml
@@ -92,3 +92,5 @@ config:
       port: 6335
     consensus:
       tick_period_ms: 100
+
+sidecarContainers: []

--- a/values.yaml
+++ b/values.yaml
@@ -94,3 +94,18 @@ config:
       tick_period_ms: 100
 
 sidecarContainers: []
+# sidecarContainers:
+#   - name: my-sidecar
+#     image: qdrant/my-sidecar-image
+#     imagePullPolicy: Always
+#     ports:
+#     - name: my-port
+#       containerPort: 5000
+#       protocol: TCP
+#     resources:
+#       requests:
+#         memory: 10Mi
+#         cpu: 10m
+#       limits:
+#         memory: 100Mi
+#         cpu: 100m


### PR DESCRIPTION
This PR is to solve #19

Basically adding support for sidecar containers. An example usecase would be;

``` yaml
# values.yaml
sidecarContainers:
  - name: my-sidecar
    image: hajali-amine/my-sidecar-image
    imagePullPolicy: Always
    ports:
    - name: my-port
      containerPort: 5000
      protocol: TCP
    resources:
      requests:
        memory: 10Mi
        cpu: 10m
      limits:
        memory: 100Mi
        cpu: 100m
```