### PR TITLE
Fix README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ helm delete your-qdrant-installation-name .
 Delete the volume with
 
 ```bash
-kubectl delete pvc -l kubectl delete pvc -l app.kubernetes.io/instance=your-qdrant-installation-name
+kubectl delete pvc -l app.kubernetes.io/instance=your-qdrant-installation-name
 ```
 
 ## Configuration


### PR DESCRIPTION
The uninstall command for pvc is incorrect 
```kubectl delete pvc -l kubectl delete pvc -l app.kubernetes.io/instance=your-qdrant-installation-name```
Should be 
```kubectl delete pvc -l app.kubernetes.io/instance=your-qdrant-installation-name```