### PR TITLE
feat/add service monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.vscode

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if and (.Values.metrics.enabled) (.Values.metrics.serviceMonitor.enabled)}}
+kind: ServiceMonitor
+apiVersion: monitoring.coreos.com/v1
+metadata:
+  labels:
+    {{- include "qdrant.labels" . | nindent 4 }}
+  name: {{ include "qdrant.fullname" . }}
+spec:
+  endpoints:
+    - honorLabels: true
+      interval: {{ .Values.metrics.serviceMonitor.scrapeInterval }}
+      path: {{ .Values.metrics.serviceMonitor.targetPath }}
+      port: {{ .Values.metrics.serviceMonitor.targetPort }}
+      scheme: http
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+  selector:
+    matchLabels:
+      {{- include "qdrant.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -15,5 +15,5 @@ spec:
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
   selector:
     matchLabels:
-      {{- include "qdrant.selectorLabels" . | nindent 6 }}
+      {{- include "qdrant.labels" . | nindent 6 }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -111,3 +111,12 @@ sidecarContainers: []
 #         cpu: 100m
 
 updateConfigurationOnChange: false
+
+metrics:
+  enabled: false
+  serviceMonitor:
+    enabled: false
+    scrapeInterval: 30s
+    scrapeTimeout: 10s
+    targetPort: rest
+    targetPath: "/metrics"


### PR DESCRIPTION
Feat:
- add an optional ServiceMonitor to ease prometheus configuration instead of reconfiguring scrape targets on Prometheus

Chore:
- Add some gitignore configs