### PR TITLE
Adding SecurityContext + enabling Qdrant to run as non-root?

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -153,4 +153,5 @@ spec:
         {{- end }}
         resources:
           requests:
-            storage: {{ .Values.persistence.size | quote }} 
+            storage: {{ .Values.persistence.size | quote }}
+

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -13,16 +13,16 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if (default .Values.updateConfigurationOnChange false) }}
+      {{- if (default .Values.updateConfigurationOnChange false) }}
         checksum/config: {{ tpl (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- end }}
-        {{- with .Values.podAnnotations }}
+      {{- end }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- end }}
       labels:
         {{- include "qdrant.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
+          {{ toYaml . | nindent 8 }}
         {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -32,7 +32,7 @@ spec:
       containers:
         {{- if .Values.sidecarContainers -}}
         {{- toYaml .Values.sidecarContainers | trim | nindent 8 }}
-        {{- end }}
+        {{- end}}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -43,6 +43,61 @@ spec:
           - name: {{ .name }}
             containerPort: {{ .targetPort }}
             protocol: {{ .protocol }}
+          {{- end }}
+
+          {{- $values := .Values -}}
+          {{- range .Values.service.ports }}
+          {{- if and $values.livenessProbe.enabled .checksEnabled }}
+          livenessProbe:
+            {{- if eq .name "grpc"}}
+            grpc:
+              port: {{ .targetPort }}
+            {{- end }}
+            {{- if eq .name "rest"}}
+            httpGet:
+              path: /
+              port: {{ .targetPort }}
+            {{- end }}
+            initialDelaySeconds: {{ $values.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ $values.livenessProbe.timeoutSeconds }}
+            periodSeconds: {{ $values.livenessProbe.periodSeconds }}
+            successThreshold: {{ $values.livenessProbe.successThreshold }}
+            failureThreshold: {{ $values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if and $values.readinessProbe.enabled .checksEnabled }}
+          readinessProbe:
+            {{- if eq .name "grpc"}}
+            grpc:
+              port: {{ .targetPort }}
+            {{- end }}
+            {{- if eq .name "rest"}}
+            httpGet:
+              path: /
+              port: {{ .targetPort }}
+            {{- end }}
+            initialDelaySeconds: {{ $values.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ $values.readinessProbe.timeoutSeconds }}
+            periodSeconds: {{ $values.readinessProbe.periodSeconds }}
+            successThreshold: {{ $values.readinessProbe.successThreshold }}
+            failureThreshold: {{ $values.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if and $values.startupProbe.enabled .checksEnabled }}
+          startupProbe:
+            {{- if eq .name "grpc"}}
+            grpc:
+              port: {{ .targetPort }}
+            {{- end }}
+            {{- if eq .name "rest"}}
+            httpGet:
+              path: /
+              port: {{ .targetPort }}
+            {{- end }}
+            initialDelaySeconds: {{ $values.startupProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ $values.startupProbe.timeoutSeconds }}
+            periodSeconds: {{ $values.startupProbe.periodSeconds }}
+            successThreshold: {{ $values.startupProbe.successThreshold }}
+            failureThreshold: {{ $values.startupProbe.failureThreshold }}
+          {{- end }}
           {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -61,6 +116,7 @@ spec:
           - name: qdrant-snapshots
             mountPath: /qdrant/snapshots
           {{- end }}
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -98,3 +154,4 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistence.size | quote }} 
+         

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -154,4 +154,4 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistence.size | quote }}
-        
+         

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -32,7 +32,7 @@ spec:
       containers:
         {{- if .Values.sidecarContainers -}}
         {{- toYaml .Values.sidecarContainers | trim | nindent 8 }}
-        {{- end}}
+        {{- end }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -44,61 +44,8 @@ spec:
               containerPort: {{ .targetPort }}
               protocol: {{ .protocol }}
           {{- end }}
-
-          {{- $values := .Values -}}
-          {{- range .Values.service.ports }}
-          {{- if and $values.livenessProbe.enabled .checksEnabled }}
-          livenessProbe:
-            {{- if eq .name "grpc"}}
-            grpc:
-              port: {{ .targetPort }}
-            {{- end }}
-            {{- if eq .name "rest"}}
-            httpGet:
-              path: /
-              port: {{ .targetPort }}
-            {{- end }}
-            initialDelaySeconds: {{ $values.livenessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ $values.livenessProbe.timeoutSeconds }}
-            periodSeconds: {{ $values.livenessProbe.periodSeconds }}
-            successThreshold: {{ $values.livenessProbe.successThreshold }}
-            failureThreshold: {{ $values.livenessProbe.failureThreshold }}
-          {{- end }}
-          {{- if and $values.readinessProbe.enabled .checksEnabled }}
-          readinessProbe:
-            {{- if eq .name "grpc"}}
-            grpc:
-              port: {{ .targetPort }}
-            {{- end }}
-            {{- if eq .name "rest"}}
-            httpGet:
-              path: /
-              port: {{ .targetPort }}
-            {{- end }}
-            initialDelaySeconds: {{ $values.readinessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ $values.readinessProbe.timeoutSeconds }}
-            periodSeconds: {{ $values.readinessProbe.periodSeconds }}
-            successThreshold: {{ $values.readinessProbe.successThreshold }}
-            failureThreshold: {{ $values.readinessProbe.failureThreshold }}
-          {{- end }}
-          {{- if and $values.startupProbe.enabled .checksEnabled }}
-          startupProbe:
-            {{- if eq .name "grpc"}}
-            grpc:
-              port: {{ .targetPort }}
-            {{- end }}
-            {{- if eq .name "rest"}}
-            httpGet:
-              path: /
-              port: {{ .targetPort }}
-            {{- end }}
-            initialDelaySeconds: {{ $values.startupProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ $values.startupProbe.timeoutSeconds }}
-            periodSeconds: {{ $values.startupProbe.periodSeconds }}
-            successThreshold: {{ $values.startupProbe.successThreshold }}
-            failureThreshold: {{ $values.startupProbe.failureThreshold }}
-          {{- end }}
-          {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
@@ -114,7 +61,6 @@ spec:
           - name: qdrant-snapshots
             mountPath: /qdrant/snapshots
           {{- end }}
-
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -136,7 +82,6 @@ spec:
         - name: qdrant-snapshots
           persistentVolumeClaim:
             claimName: {{ .Values.snapshotRestoration.pvcName }}
-        {{- end }}
 
   volumeClaimTemplates:
     - metadata:

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -153,5 +153,5 @@ spec:
         {{- end }}
         resources:
           requests:
-            storage: {{ .Values.persistence.size | quote }}
+            storage: {{ .Values.persistence.size | quote }} 
          

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -40,9 +40,9 @@ spec:
           args: ["./config/initialize.sh"]
           ports:
           {{- range .Values.service.ports }}
-          - name: {{ .name }}
-            containerPort: {{ .targetPort }}
-            protocol: {{ .protocol }}
+            - name: {{ .name }}
+              containerPort: {{ .targetPort }}
+              protocol: {{ .protocol }}
           {{- end }}
 
           {{- $values := .Values -}}
@@ -154,4 +154,3 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistence.size | quote }} 
-         

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -13,16 +13,16 @@ spec:
   template:
     metadata:
       annotations:
-      {{- if (default .Values.updateConfigurationOnChange false) }}
+        {{- if (default .Values.updateConfigurationOnChange false) }}
         checksum/config: {{ tpl (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-      {{- end }}
-      {{- with .Values.podAnnotations }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "qdrant.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
-          {{ toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -40,9 +40,9 @@ spec:
           args: ["./config/initialize.sh"]
           ports:
           {{- range .Values.service.ports }}
-            - name: {{ .name }}
-              containerPort: {{ .targetPort }}
-              protocol: {{ .protocol }}
+          - name: {{ .name }}
+            containerPort: {{ .targetPort }}
+            protocol: {{ .protocol }}
           {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -82,6 +82,7 @@ spec:
         - name: qdrant-snapshots
           persistentVolumeClaim:
             claimName: {{ .Values.snapshotRestoration.pvcName }}
+        {{- end }}
 
   volumeClaimTemplates:
     - metadata:
@@ -97,4 +98,3 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistence.size | quote }} 
-         

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -154,4 +154,4 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistence.size | quote }}
-
+        

--- a/values.yaml
+++ b/values.yaml
@@ -77,7 +77,7 @@ securityContext:
   runAsUser: 1000
   allowPrivilegeEscalation: false
   runAsNonRoot: true
-  
+
 resources: {}
   # limits:
   #   cpu: 100m

--- a/values.yaml
+++ b/values.yaml
@@ -70,6 +70,8 @@ startupProbe:
   failureThreshold: 30
   successThreshold: 1
 
+securityContext: {}
+
 podAnnotations: {}
 podLabels: {}
 

--- a/values.yaml
+++ b/values.yaml
@@ -70,11 +70,14 @@ startupProbe:
   failureThreshold: 30
   successThreshold: 1
 
-securityContext: {}
-
 podAnnotations: {}
 podLabels: {}
 
+securityContext:
+  runAsUser: 1000
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  
 resources: {}
   # limits:
   #   cpu: 100m


### PR DESCRIPTION
The current Helm chart does not support the securityContext parameter, causing errors when trying to deploy in environments where the container cannot run as root.

To address this issue, I have added the missing securityContext definition in the values.yaml file and made modifications to the template. This change allows successful deployment without the previous `container has runAsNonRoot and image will run as root` error.

However, I encountered a new problem where the Qdrant image is still running as root, resulting in permission denied errors for critical paths, such as creating the Snapshots directory:


`[2023-07-06T14:10:18.151Z ERROR qdrant::startup] Panic occurred in file lib/storage/src/content_manager/toc.rs at line 107: Can't create Snapshots directory: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }`

I believe we should modify the Dockerfile to change the permissions of the critical folders to the same user ID we specify in securityContext. However, I would appreciate any advice or suggestions regarding the best approach to address this issue.

Thank you for your assistance!