### PR TITLE
Fixes ingress declaration when using TLS

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -29,11 +29,13 @@ spec:
   {{- end }}
   {{- with .Values.ingress.tls }}
   tls:
+    {{- range . }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
         {{- end }}
       secretName: {{ .secretName | quote }}
+    {{- end }}
   {{- end }}
 {{- end }}
 


### PR DESCRIPTION
If you run the chart with `ingress.enabled: true` along with a `tls` declaration, the installation fail due to an invalid template.

Steps to reproduce:

1) Modify your `values.yaml` file to enable the ingress and provide a `tls` section.

```yaml
ingress:
  enabled: true
  annotations: {}
    # kubernetes.io/ingress.class: alb
  hosts:
    - host: example-domain.com
      paths:
        - path: /
          pathType: Prefix
          servicePort: 6333
  tls:
    - hosts:
        - example-domain.com
      secretName: tls-secret-name
```

2) Attempt to install the latest published chart, you should see an error: 

```text
helm upgrade --install your-qdrant-installation-name qdrant/qdrant -f values.yaml

Release "your-qdrant-installation-name" does not exist. Installing it now.
Error: template: qdrant/templates/ingress.yaml:33:18: executing "qdrant/templates/ingress.yaml" at <.hosts>: can't evaluate field hosts in type []interface {}

```

3) Attempt to install the chart from this PR, it should install correctly

```text
helm upgrade --install your-qdrant-installation-name . -f values.yaml

Release "your-qdrant-installation-name" does not exist. Installing it now.
NAME: your-qdrant-installation-name
LAST DEPLOYED: Mon Jul 24 19:45:17 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
```