### PR TITLE
Change target port for serviceMonitor to rely on new naming (http)

### DIFF
--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -133,5 +133,5 @@ metrics:
     enabled: false
     scrapeInterval: 30s
     scrapeTimeout: 10s
-    targetPort: rest
+    targetPort: http
     targetPath: "/metrics"


### PR DESCRIPTION
Regarding the change of the port naming introduce with 0.3.0 (rest --> http), targetPort for the serviceMonitor must be renamed