### PR TITLE
Make the qdrant api key easily configurable

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -43,3 +43,9 @@ jobs:
 
       - name: Run chart-testing
         run: ct install --all --upgrade --target-branch main
+
+      - name: Setup BATS
+        uses: mig4/setup-bats@v1
+
+      - name: Run integration tests
+        run: bats test/integration

--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Setup BATS
         uses: mig4/setup-bats@v1
+        with:
+          bats-version: 1.10.0
 
       - name: Run integration tests
         run: bats test/integration --verbose-run --show-output-of-passing-test

--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -48,4 +48,4 @@ jobs:
         uses: mig4/setup-bats@v1
 
       - name: Run integration tests
-        run: bats test/integration
+        run: bats test/integration --verbose-run --show-output-of-passing-test

--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -50,4 +50,4 @@ jobs:
           bats-version: 1.10.0
 
       - name: Run integration tests
-        run: bats test/integration --verbose-run --show-output-of-passing-test
+        run: bats test/integration --verbose-run --show-output-of-passing-tests

--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ test-integration:
 	kubectl get pods
 	helm test qdrant
 	kind delete cluster -n qdrant-helm-integration
-	bats test/integration
+	bats test/integration --verbose-run --show-output-of-passing-test

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,4 @@ test-integration:
 	kubectl get pods
 	helm test qdrant
 	kind delete cluster -n qdrant-helm-integration
+	bats test/integration

--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ test-integration:
 	kubectl get pods
 	helm test qdrant
 	kind delete cluster -n qdrant-helm-integration
-	bats test/integration --verbose-run --show-output-of-passing-test
+	bats test/integration --verbose-run --show-output-of-passing-tests

--- a/README.md
+++ b/README.md
@@ -11,3 +11,67 @@ This repository hosts the following helm charts:
 ```bash
 helm repo add qdrant https://qdrant.github.io/qdrant-helm
 ```
+
+## Running tests
+
+This repository has unit and integration tests for the charts. All charts are also linted.
+
+### Linting
+
+Linting is done with `helm lint`.
+
+Prerequisites:
+
+* Helm
+
+```bash
+brew install helm
+```
+
+To lint all charts:
+
+```bash
+make lint
+```
+
+### Unit tests
+
+Unit tests are in the `./test` directory and written in Go with [terratest](https://github.com/gruntwork-io/terratest).
+
+Prerequisites:
+
+* Go
+
+```bash
+brew install go
+```
+
+To run the tests:
+
+```bash
+make test-unit
+```
+
+### Integration tests
+
+Integration tests are in the `./test/integration` directory and written with [bats](https://bats-core.readthedocs.io/).
+
+There is an additional simple Helm test in `./charts/qdrant/templates/tests`.
+
+Prerequisites:
+
+* Docker
+* Kind
+* Kubectl
+* Helm
+* Bats
+
+```bash
+brew install helm kubectl kind bats-core homebrew/cask/docker
+```
+
+To run the tests:
+
+```bash
+make test-integration
+```

--- a/charts/qdrant/templates/secret.yaml
+++ b/charts/qdrant/templates/secret.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.apiKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "qdrant.fullname" . }}-apikey
+data:
+{{ include "qdrant.secret" . | indent 2}}
+{{- end }}

--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -152,10 +152,8 @@ spec:
             mountPath: /qdrant/config/local.yaml
             subPath: local.yaml
           {{- end }}
-          {{- if .Values.snapshotRestoration.enabled }}
           - name: qdrant-snapshots
             mountPath: /qdrant/snapshots
-          {{- end }}
           {{- if .Values.additionalVolumeMounts }}
 {{- toYaml .Values.additionalVolumeMounts | default "" | nindent 10 }}
           {{- end}}

--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -147,8 +147,18 @@ spec:
           - name: qdrant-config
             mountPath: /qdrant/config/production.yaml
             subPath: production.yaml
+          {{- if .Values.apiKey }}
+          - name: qdrant-secret
+            mountPath: /qdrant/config/local.yaml
+            subPath: local.yaml
+          {{- end }}
+          {{- if .Values.snapshotRestoration.enabled }}
           - name: qdrant-snapshots
             mountPath: /qdrant/snapshots
+          {{- end }}
+          {{- if .Values.additionalVolumeMounts }}
+{{- toYaml .Values.additionalVolumeMounts | default "" | nindent 10 }}
+          {{- end}}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -179,6 +189,15 @@ spec:
         - name: qdrant-snapshots
           emptyDir: {}
         {{- end }}
+        {{- if .Values.apiKey }}
+        - name: qdrant-secret
+          secret:
+            secretName: {{ include "qdrant.fullname" . }}-apikey
+            defaultMode: 0600
+        {{- end }}
+        {{- if .Values.additionalVolumes }}
+{{- toYaml .Values.additionalVolumes | default "" | nindent 8 }}
+        {{- end}}
   volumeClaimTemplates:
     - metadata:
         name: qdrant-storage

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -171,3 +171,17 @@ podDisruptionBudget:
   # do not enable if you are using not in 1.27
   unhealthyPodEvictionPolicy: ""
   # minAvailable: 1
+
+# api key for authentication at qdrant
+# false: no api key will be configured
+# true: an api key will be auto-generated
+# string: the give string will be set as an apikey
+apiKey: false
+
+additionalVolumes: []
+# - name: volumeName
+#   emptyDir: {}
+
+additionalVolumeMounts: []
+# - name: volumeName
+#   mountPath: "/mount/path"

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -175,7 +175,7 @@ podDisruptionBudget:
 # api key for authentication at qdrant
 # false: no api key will be configured
 # true: an api key will be auto-generated
-# string: the give string will be set as an apikey
+# string: the given string will be set as an apikey
 apiKey: false
 
 additionalVolumes: []

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21.0
 require (
 	github.com/gruntwork-io/terratest v0.43.12
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.67.1
+	github.com/samber/lo v1.38.1
 	github.com/stretchr/testify v1.8.4
 	k8s.io/api v0.28.0
 )
@@ -48,6 +49,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/urfave/cli v1.22.2 // indirect
 	golang.org/x/crypto v0.11.0 // indirect
+	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 	golang.org/x/net v0.13.0 // indirect
 	golang.org/x/oauth2 v0.8.0 // indirect
 	golang.org/x/sys v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncj
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/samber/lo v1.38.1 h1:j2XEAqXKb09Am4ebOg31SpvzUTTs6EN3VfgeLUhPdXM=
+github.com/samber/lo v1.38.1/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -141,6 +143,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.11.0 h1:6Ewdq3tDic1mg5xRO4milcWCfMVQhI4NkqWWvqejpuA=
 golang.org/x/crypto v0.11.0/go.mod h1:xgJhtzW8F9jGdVFWZESrid1U1bjeNy4zgy5cRr/CIio=
+golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 h1:3MTrJm4PyNL9NBqvYDSj3DHl46qQakyfqfWo4jgfaEM=
+golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/test/integration/api_key.bats
+++ b/test/integration/api_key.bats
@@ -1,0 +1,21 @@
+setup_file() {
+    kubectl create namespace qdrant-helm-integration
+    kubectl create serviceaccount default -n qdrant-helm-integration || true
+    helm install qdrant charts/qdrant --set apiKey=foobar -n qdrant-helm-integration
+}
+
+teardown_file() {
+    helm uninstall qdrant -n qdrant-helm-integration
+    kubectl delete serviceaccount default -n qdrant-helm-integration
+    kubectl delete namespace qdrant-helm-integration
+}
+
+@test "api key authentication works" {
+    run kubectl -n qdrant-helm-integration run --rm -i -t api-key-test-works --image=curlimages/curl -- http://qdrant:6333/collections -H 'api-key: foobar'
+    [ $status -eq 0 ]
+}
+
+@test "api key authentication fails with key" {
+    run kubectl -n qdrant-helm-integration run --rm -i -t api-key-test-fails --image=curlimages/curl -- http://qdrant:6333/collections
+    [ $status -ne 0 ]
+}

--- a/test/integration/api_key.bats
+++ b/test/integration/api_key.bats
@@ -12,12 +12,12 @@ teardown_file() {
 }
 
 @test "api key authentication works" {
-    run kubectl exec -it -n default curl -- curl http://qdrant.qdrant-helm-integration:6333/collections -H 'api-key: foobar'
+    run kubectl exec -n default curl -- curl -s http://qdrant.qdrant-helm-integration:6333/collections -H 'api-key: foobar'
     [ $status -eq 0 ]
     [ "${output}" != "Invalid api-key" ]
 }
 
 @test "api key authentication fails with key" {
-    run kubectl exec -it -n default curl -- curl http://qdrant.qdrant-helm-integration:6333/collections
+    run kubectl exec -n default curl -- curl -s http://qdrant.qdrant-helm-integration:6333/collections
     [ "${output}" = "Invalid api-key" ]
 }

--- a/test/integration/random_api_key.bats
+++ b/test/integration/random_api_key.bats
@@ -14,7 +14,7 @@ teardown_file() {
 @test "random api key works" {
     apiKey=$(kubectl -n qdrant-helm-integration get secret qdrant-apikey -o jsonpath="{.data.api-key}" | base64 --decode)
     [ ${#apiKey} -eq 32 ]
-    run kubectl exec -it -n default curl -- curl http://qdrant.qdrant-helm-integration:6333/collections -H "api-key: ${apiKey}"
+    run kubectl exec -n default curl -- curl -s http://qdrant.qdrant-helm-integration:6333/collections -H "api-key: ${apiKey}"
     [ $status -eq 0 ]
     [ "${output}" != "Invalid api-key" ]
 }

--- a/test/integration/random_api_key.bats
+++ b/test/integration/random_api_key.bats
@@ -1,7 +1,8 @@
 setup_file() {
     kubectl create namespace qdrant-helm-integration
     kubectl create serviceaccount default -n qdrant-helm-integration || true
-    helm install qdrant charts/qdrant --set apiKey=true -n qdrant-helm-integration
+    helm install qdrant charts/qdrant --set apiKey=true -n qdrant-helm-integration --wait
+    kubectl rollout status statefulset qdrant -n qdrant-helm-integration
 }
 
 teardown_file() {
@@ -12,13 +13,18 @@ teardown_file() {
 
 @test "random api key works" {
     apiKey=$(kubectl -n qdrant-helm-integration get secret qdrant-apikey -o jsonpath="{.data.api-key}" | base64 --decode)
-    run kubectl -n qdrant-helm-integration run --rm -i -t api-key-test-works --image=curlimages/curl -- http://qdrant:6333/collections -H "api-key: ${apiKey}"
+    [ ${#apiKey} -eq 32 ]
+    run kubectl exec -it -n default curl -- curl http://qdrant.qdrant-helm-integration:6333/collections -H "api-key: ${apiKey}"
     [ $status -eq 0 ]
+    [ "${output}" != "Invalid api-key" ]
 }
 
 @test "random api key stays the same after upgrade" {
     apiKeyBeforeUpgrade=$(kubectl -n qdrant-helm-integration get secret qdrant-apikey -o jsonpath="{.data.api-key}" | base64 --decode)
-    helm upgrade qdrant charts/qdrant --set apiKey=true -n qdrant-helm-integration
+    helm upgrade qdrant charts/qdrant --set apiKey=true -n qdrant-helm-integration --wait
+    kubectl rollout status statefulset qdrant -n qdrant-helm-integration
     apiKeyAfterUpgrade=$(kubectl -n qdrant-helm-integration get secret qdrant-apikey -o jsonpath="{.data.api-key}" | base64 --decode)
     [ "${apiKeyBeforeUpgrade}" = "${apiKeyAfterUpgrade}" ]
+    [ ${#apiKeyBeforeUpgrade} -eq 32 ]
+    [ ${#apiKeyAfterUpgrade} -eq 32 ]
 }

--- a/test/integration/random_api_key.bats
+++ b/test/integration/random_api_key.bats
@@ -1,0 +1,24 @@
+setup_file() {
+    kubectl create namespace qdrant-helm-integration
+    kubectl create serviceaccount default -n qdrant-helm-integration || true
+    helm install qdrant charts/qdrant --set apiKey=true -n qdrant-helm-integration
+}
+
+teardown_file() {
+    helm uninstall qdrant -n qdrant-helm-integration
+    kubectl delete serviceaccount default -n qdrant-helm-integration
+    kubectl delete namespace qdrant-helm-integration
+}
+
+@test "random api key works" {
+    apiKey=$(kubectl -n qdrant-helm-integration get secret qdrant-apikey -o jsonpath="{.data.api-key}" | base64 --decode)
+    run kubectl -n qdrant-helm-integration run --rm -i -t api-key-test-works --image=curlimages/curl -- http://qdrant:6333/collections -H "api-key: ${apiKey}"
+    [ $status -eq 0 ]
+}
+
+@test "random api key stays the same after upgrade" {
+    apiKeyBeforeUpgrade=$(kubectl -n qdrant-helm-integration get secret qdrant-apikey -o jsonpath="{.data.api-key}" | base64 --decode)
+    helm upgrade qdrant charts/qdrant --set apiKey=true -n qdrant-helm-integration
+    apiKeyAfterUpgrade=$(kubectl -n qdrant-helm-integration get secret qdrant-apikey -o jsonpath="{.data.api-key}" | base64 --decode)
+    [ "${apiKeyBeforeUpgrade}" = "${apiKeyAfterUpgrade}" ]
+}

--- a/test/integration/setup_suite.bash
+++ b/test/integration/setup_suite.bash
@@ -1,0 +1,7 @@
+setup_suite() {
+    kind create cluster -n qdrant-helm-integration
+}
+
+teardown_suite() {
+    kind delete cluster -n qdrant-helm-integration
+}

--- a/test/integration/setup_suite.bash
+++ b/test/integration/setup_suite.bash
@@ -1,5 +1,8 @@
 setup_suite() {
     kind create cluster -n qdrant-helm-integration
+    kubectl create serviceaccount default -n default
+    kubectl -n default run curl --image=curlimages/curl --command -- sh -c "sleep 3600"
+    kubectl wait --for=condition=Ready pod/curl -n default --timeout=300s
 }
 
 teardown_suite() {

--- a/test/qdrant_additional_volume_test.go
+++ b/test/qdrant_additional_volume_test.go
@@ -1,0 +1,58 @@
+package test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestAdditionalVolumeAndVolumeMount(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs("../charts/qdrant")
+	releaseName := "qdrant"
+	require.NoError(t, err)
+
+	namespaceName := "qdrant-" + strings.ToLower(random.UniqueId())
+	logger.Log(t, "Namespace: %s\n", namespaceName)
+
+	options := &helm.Options{
+		SetJsonValues: map[string]string{
+			"additionalVolumes":      `[{"name":"volumeName","emptyDir":{"sizeLimit":"500Mi"}}]`,
+			"additionalVolumeMounts": `[{"name":"volumeName","mountPath":"/mount/path"}]`,
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/statefulset.yaml"})
+
+	var statefulSet appsv1.StatefulSet
+	helm.UnmarshalK8SYaml(t, output, &statefulSet)
+
+	container, _ := lo.Find(statefulSet.Spec.Template.Spec.Containers, func(container corev1.Container) bool {
+		return container.Name == "qdrant"
+	})
+
+	volumeMount, hasAdditionalVolumeMount := lo.Find(container.VolumeMounts, func(volumeMount corev1.VolumeMount) bool {
+		return volumeMount.Name == "volumeName"
+	})
+
+	volume, hasAdditionalVolume := lo.Find(statefulSet.Spec.Template.Spec.Volumes, func(volume corev1.Volume) bool {
+		return volume.Name == "volumeName"
+	})
+
+	require.Equal(t, hasAdditionalVolumeMount, true)
+	require.Equal(t, hasAdditionalVolume, true)
+
+	require.Equal(t, "/mount/path", volumeMount.MountPath)
+	require.Equal(t, "500Mi", volume.EmptyDir.SizeLimit.String())
+}

--- a/test/qdrant_api_key_test.go
+++ b/test/qdrant_api_key_test.go
@@ -1,0 +1,146 @@
+package test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestStringApiKey(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs("../charts/qdrant")
+	releaseName := "qdrant"
+	require.NoError(t, err)
+
+	namespaceName := "qdrant-" + strings.ToLower(random.UniqueId())
+	logger.Log(t, "Namespace: %s\n", namespaceName)
+
+	options := &helm.Options{
+		SetJsonValues: map[string]string{
+			"apiKey": `"test_api_key"`,
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/statefulset.yaml"})
+
+	var statefulSet appsv1.StatefulSet
+	helm.UnmarshalK8SYaml(t, output, &statefulSet)
+
+	output = helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/secret.yaml"})
+
+	var secret corev1.Secret
+	helm.UnmarshalK8SYaml(t, output, &secret)
+
+	container, _ := lo.Find(statefulSet.Spec.Template.Spec.Containers, func(container corev1.Container) bool {
+		return container.Name == "qdrant"
+	})
+
+	secretVolumeMount, hasSecretVolumeMount := lo.Find(container.VolumeMounts, func(volumeMount corev1.VolumeMount) bool {
+		return volumeMount.Name == "qdrant-secret"
+	})
+
+	_, hasSecretVolume := lo.Find(statefulSet.Spec.Template.Spec.Volumes, func(volume corev1.Volume) bool {
+		return volume.Name == secretVolumeMount.Name
+	})
+
+	require.Equal(t, hasSecretVolumeMount, true)
+	require.Equal(t, hasSecretVolume, true)
+	require.Contains(t, lo.Keys(secret.Data), "local.yaml")
+	require.Contains(t, lo.Keys(secret.Data), "api-key")
+
+	require.Equal(t, "service:\n  api_key: test_api_key", string(secret.Data["local.yaml"]))
+}
+
+func TestRandomApiKey(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs("../charts/qdrant")
+	releaseName := "qdrant"
+	require.NoError(t, err)
+
+	namespaceName := "qdrant-" + strings.ToLower(random.UniqueId())
+	logger.Log(t, "Namespace: %s\n", namespaceName)
+
+	options := &helm.Options{
+		SetJsonValues: map[string]string{
+			"apiKey": `true`,
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/statefulset.yaml"})
+
+	var statefulSet appsv1.StatefulSet
+	helm.UnmarshalK8SYaml(t, output, &statefulSet)
+
+	output = helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/secret.yaml"})
+
+	var secret corev1.Secret
+	helm.UnmarshalK8SYaml(t, output, &secret)
+
+	container, _ := lo.Find(statefulSet.Spec.Template.Spec.Containers, func(container corev1.Container) bool {
+		return container.Name == "qdrant"
+	})
+
+	secretVolumeMount, hasSecretVolumeMount := lo.Find(container.VolumeMounts, func(volumeMount corev1.VolumeMount) bool {
+		return volumeMount.Name == "qdrant-secret"
+	})
+
+	_, hasSecretVolume := lo.Find(statefulSet.Spec.Template.Spec.Volumes, func(volume corev1.Volume) bool {
+		return volume.Name == secretVolumeMount.Name
+	})
+
+	require.Equal(t, hasSecretVolumeMount, true)
+	require.Equal(t, hasSecretVolume, true)
+	require.Contains(t, lo.Keys(secret.Data), "local.yaml")
+	require.Contains(t, lo.Keys(secret.Data), "api-key")
+
+	require.Regexp(t, "^service:\n  api_key: [a-zA-Z0-9]+$", string(secret.Data["local.yaml"]))
+}
+
+func TestNoApiKey(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs("../charts/qdrant")
+	releaseName := "qdrant"
+	require.NoError(t, err)
+
+	namespaceName := "qdrant-" + strings.ToLower(random.UniqueId())
+	logger.Log(t, "Namespace: %s\n", namespaceName)
+
+	options := &helm.Options{
+		SetJsonValues:  map[string]string{},
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/statefulset.yaml"})
+
+	var statefulSet appsv1.StatefulSet
+	helm.UnmarshalK8SYaml(t, output, &statefulSet)
+
+	container, _ := lo.Find(statefulSet.Spec.Template.Spec.Containers, func(container corev1.Container) bool {
+		return container.Name == "qdrant"
+	})
+
+	_, hasSecretVolumeMount := lo.Find(container.VolumeMounts, func(volumeMount corev1.VolumeMount) bool {
+		return volumeMount.Name == "qdrant-secret"
+	})
+
+	_, hasSecretVolume := lo.Find(statefulSet.Spec.Template.Spec.Volumes, func(volume corev1.Volume) bool {
+		return volume.Name == "qdrant-secret"
+	})
+
+	require.Equal(t, hasSecretVolumeMount, false)
+	require.Equal(t, hasSecretVolume, false)
+}


### PR DESCRIPTION
This adds a new `apiKey` value.

If `true` it generates a random apiKey, stores it in a secret and ensures that it stays the same during upgrades. If a string is passed, this string is used as the api key.

The secret is mounted as a `local.yaml` config into the container. See also https://qdrant.tech/documentation/guides/configuration/#order-and-priority.

Alternatively, there are two new values `additionalVolumes` and `additionalVolumeMounts` which allow to mount additional existing volumes, such as pre-existing secrets into the qdrant container.

This also adds bats-core based integration tests to test the correct api key handling.

Fixes https://github.com/qdrant/qdrant-helm/issues/46