### PR TITLE
Make pod topologySpreadConstraints configurable

### DIFF
--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -170,6 +170,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints}}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "qdrant.fullname" . }}
       volumes:
         - name: qdrant-config

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -110,6 +110,8 @@ tolerations: []
 
 affinity: {}
 
+topologySpreadConstraints: []
+
 persistence:
   accessModes: ["ReadWriteOnce"]
   size: 10Gi

--- a/test/qdrant_topology-spread-constraints_test.go
+++ b/test/qdrant_topology-spread-constraints_test.go
@@ -1,0 +1,40 @@
+package test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func TestTopologySpreadConstraints(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs("../charts/qdrant")
+	releaseName := "qdrant"
+	require.NoError(t, err)
+
+	namespaceName := "qdrant-" + strings.ToLower(random.UniqueId())
+	logger.Log(t, "Namespace: %s\n", namespaceName)
+
+	options := &helm.Options{
+		SetJsonValues: map[string]string{
+			"topologySpreadConstraints": `[{"maxSkew":1,"topologyKey":"kubernetes.io/hostname","whenUnsatisfiable":"DoNotSchedule","labelSelector":{"matchLabels":{"app":"qdrant"}}}]`,
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/statefulset.yaml"})
+
+	var statefulSet appsv1.StatefulSet
+	helm.UnmarshalK8SYaml(t, output, &statefulSet)
+
+	require.Equal(t, 1, len(statefulSet.Spec.Template.Spec.TopologySpreadConstraints))
+	require.Equal(t, int32(1), statefulSet.Spec.Template.Spec.TopologySpreadConstraints[0].MaxSkew)
+}


### PR DESCRIPTION
Fixes https://github.com/qdrant/qdrant-helm/issues/65 
More info https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/