### PR TITLE
Add PriorityClass support to StatefulSet Pod template

### DIFF
--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -32,6 +32,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
       initContainers:
       {{- if .Values.updateVolumeFsOwnership }}
       {{- if and .Values.containerSecurityContext .Values.containerSecurityContext.runAsUser }}

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -170,6 +170,8 @@ metrics:
     ##
     relabelings: []
 
+priorityClassName: ""
+
 podDisruptionBudget:
   enabled: false
   maxUnavailable: 1


### PR DESCRIPTION
Adds [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) support to the Qdrant StatefulSet Pod template, allowing prioritization of scheduling after something such as an eviction scenario.