### PR TITLE
Don't use alpine image for file permission updates

### DIFF
--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -39,7 +39,7 @@ spec:
       {{- if .Values.updateVolumeFsOwnership }}
       {{- if and .Values.containerSecurityContext .Values.containerSecurityContext.runAsUser }}
       - name: ensure-storage-dir-ownership
-        image: alpine:latest
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         command:
           - chown
           - -R
@@ -50,7 +50,7 @@ spec:
             mountPath: /qdrant/storage
       {{- if .Values.snapshotRestoration.enabled }}
       - name: ensure-snapshots-dir-ownership
-        image: alpine:latest
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         command:
           - chown
           - -R

--- a/test/integration/security_context.bats
+++ b/test/integration/security_context.bats
@@ -1,0 +1,24 @@
+setup_file() {
+    kubectl create namespace qdrant-helm-integration
+    kubectl create serviceaccount default -n qdrant-helm-integration || true
+}
+
+teardown_file() {
+    helm uninstall qdrant -n qdrant-helm-integration
+    kubectl delete serviceaccount default -n qdrant-helm-integration
+    kubectl delete namespace qdrant-helm-integration
+}
+
+@test "update without security context to security context corrects file permissions" {
+    helm install qdrant charts/qdrant --set-json 'podSecurityContext=false,containerSecurityContext=false' -n qdrant-helm-integration --wait
+    kubectl rollout status statefulset qdrant -n qdrant-helm-integration
+    user=$(kubectl exec qdrant-0 -n qdrant-helm-integration -- id -u)
+    [ "${user}" = "0" ]
+    user=$(kubectl exec qdrant-0 -n qdrant-helm-integration -- whoami)
+    [ "${user}" = "root" ]
+    helm upgrade --reset-values qdrant charts/qdrant -n qdrant-helm-integration --wait
+    kubectl rollout status statefulset qdrant -n qdrant-helm-integration
+    user=$(kubectl exec qdrant-0 -n qdrant-helm-integration -- id -u)
+    [ "${user}" = "1000" ]
+
+}


### PR DESCRIPTION
Using an additional image makes compliance validations harder.

This also adds a test if the upgrade from root to nonRoot works correctly.