### PR TITLE
Deactivate liveness and startup probes by default

### DIFF
--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -54,7 +54,7 @@ ingress:
     #   secretName: tls-secret-name
 
 livenessProbe:
-  enabled: true
+  enabled: false
   initialDelaySeconds: 5
   periodSeconds: 5
   timeoutSeconds: 1
@@ -70,7 +70,7 @@ readinessProbe:
   successThreshold: 1
 
 startupProbe:
-  enabled: true
+  enabled: false
   initialDelaySeconds: 10
   periodSeconds: 5
   timeoutSeconds: 1

--- a/test/qdrant_probes_test.go
+++ b/test/qdrant_probes_test.go
@@ -38,7 +38,7 @@ func TestDefaultProbesOnStatefulset(t *testing.T) {
 		return container.Name == "qdrant"
 	})
 
-	require.Equal(t, "/readyz", container.StartupProbe.HTTPGet.Path)
+	require.Empty(t, container.StartupProbe)
 	require.Equal(t, "/readyz", container.ReadinessProbe.HTTPGet.Path)
-	require.Equal(t, "/livez", container.LivenessProbe.HTTPGet.Path)
+	require.Empty(t, container.LivenessProbe)
 }


### PR DESCRIPTION
Since these probes restart the pod on failure, they can disrupt the health of the Qdrant cluster unnecessarily and cause more problems then actually help. Having a readinessProbe is usually enough.