### PR TITLE
BREAKING: Propagate signals to qdrant by changing command/args

### DIFF
--- a/charts/qdrant/templates/configmap.yaml
+++ b/charts/qdrant/templates/configmap.yaml
@@ -8,13 +8,13 @@ data:
     SET_INDEX=${HOSTNAME##*-}
     {{- if and (.Values.snapshotRestoration.enabled) (eq (.Values.replicaCount | quote)  (1 | quote)) }}
     echo "Starting initializing for pod $SET_INDEX and snapshots restoration"
-    ./entrypoint.sh {{ range .Values.snapshotRestoration.snapshots }} --snapshot {{ . }} {{ end }}
+    exec ./entrypoint.sh {{ range .Values.snapshotRestoration.snapshots }} --snapshot {{ . }} {{ end }}
     {{- else }}
     echo "Starting initializing for pod $SET_INDEX"
     if [ "$SET_INDEX" = "0" ]; then
-      ./entrypoint.sh --uri 'http://{{ include "qdrant.fullname" . }}-0.{{ include "qdrant.fullname" . }}-headless:6335'
+      exec ./entrypoint.sh --uri 'http://{{ include "qdrant.fullname" . }}-0.{{ include "qdrant.fullname" . }}-headless:6335'
     else
-      ./entrypoint.sh --bootstrap 'http://{{ include "qdrant.fullname" . }}-0.{{ include "qdrant.fullname" . }}-headless:6335' --uri 'http://{{ include "qdrant.fullname" . }}-'"$SET_INDEX"'.{{ include "qdrant.fullname" . }}-headless:6335'
+      exec ./entrypoint.sh --bootstrap 'http://{{ include "qdrant.fullname" . }}-0.{{ include "qdrant.fullname" . }}-headless:6335' --uri 'http://{{ include "qdrant.fullname" . }}-'"$SET_INDEX"'.{{ include "qdrant.fullname" . }}-headless:6335'
     fi
     {{ end }}
   production.yaml: |

--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -76,7 +76,10 @@ spec:
             - name: {{ .name }}
               value: {{ .value | quote }}
           {{- end }}
-          command: ["/bin/sh", "-c"]
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
           {{- with .Values.args }}
           args:
             {{- toYaml . | nindent 10 }}
@@ -233,12 +236,11 @@ spec:
         {{- toYaml . | nindent 10 }}
         {{- end }}
       spec:
-        storageClassName: {{ .Values.persistence.storageClassName }} 
+        storageClassName: {{ .Values.persistence.storageClassName }}
         accessModes:
         {{- range .Values.persistence.accessModes }}
           - {{ . | quote }}
         {{- end }}
         resources:
           requests:
-            storage: {{ .Values.persistence.size | quote }} 
-         
+            storage: {{ .Values.persistence.size | quote }}

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -9,7 +9,9 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
-args: ["./config/initialize.sh"]
+# If you override command/args, make sure POSIX signals are still propagated to Qdrant
+command: ["./config/initialize.sh"]
+args: []
 env: {}
   # - name: QDRANT_ALLOW_RECOVERY_MODE
   #   value: true

--- a/test/integration/default_installation.bats
+++ b/test/integration/default_installation.bats
@@ -21,3 +21,11 @@ setup_file() {
     [[ "${output}" =~ .*INFO.* ]]
     [[ ! "${output}" =~ .*ERR.* ]]
 }
+
+@test "SIGTERM signals are propagated to qdrant" {
+    run kubectl rollout restart sts/qdrant -n qdrant-helm-integration
+    [ $status -eq 0 ]
+    # If signals aren't working, this will take >30 seconds and time out
+    run kubectl rollout status statefulset qdrant -n qdrant-helm-integration --timeout=15s
+    [ $status -eq 0 ]
+}


### PR DESCRIPTION
Currently, the helm chart runs `/bin/sh` as PID 1 which does not catch signals or send them to child processes. As a result, when you delete a qdrant pod right now, it will take the full `terminationGracePeriodSeconds` and then get SIGKILLed.

NOTE FOR THE CHANGELOG: 
> This release includes a **breaking change** to the `args` value. Users who were overriding the default `args` with their own shell commands will now need to also set `command: ['/bin/sh', '-c']`. We recommend that you ensure signals are still being propagated to qdrant if you override `args` or `command` to ensure qdrant can shut down gracefully.

It is technically possible to make this a non-breaking change (use the old `command` if custom `args` are supplied), but I think it's unlikely users' custom `args` are capable of respecting signals with `/bin/sh` as PID 1.