### PR TITLE
Propagate signals to qdrant by using /bin/bash and exec

### DIFF
--- a/charts/qdrant/templates/configmap.yaml
+++ b/charts/qdrant/templates/configmap.yaml
@@ -8,13 +8,13 @@ data:
     SET_INDEX=${HOSTNAME##*-}
     {{- if and (.Values.snapshotRestoration.enabled) (eq (.Values.replicaCount | quote)  (1 | quote)) }}
     echo "Starting initializing for pod $SET_INDEX and snapshots restoration"
-    ./entrypoint.sh {{ range .Values.snapshotRestoration.snapshots }} --snapshot {{ . }} {{ end }}
+    exec ./entrypoint.sh {{ range .Values.snapshotRestoration.snapshots }} --snapshot {{ . }} {{ end }}
     {{- else }}
     echo "Starting initializing for pod $SET_INDEX"
     if [ "$SET_INDEX" = "0" ]; then
-      ./entrypoint.sh --uri 'http://{{ include "qdrant.fullname" . }}-0.{{ include "qdrant.fullname" . }}-headless:6335'
+      exec ./entrypoint.sh --uri 'http://{{ include "qdrant.fullname" . }}-0.{{ include "qdrant.fullname" . }}-headless:6335'
     else
-      ./entrypoint.sh --bootstrap 'http://{{ include "qdrant.fullname" . }}-0.{{ include "qdrant.fullname" . }}-headless:6335' --uri 'http://{{ include "qdrant.fullname" . }}-'"$SET_INDEX"'.{{ include "qdrant.fullname" . }}-headless:6335'
+      exec ./entrypoint.sh --bootstrap 'http://{{ include "qdrant.fullname" . }}-0.{{ include "qdrant.fullname" . }}-headless:6335' --uri 'http://{{ include "qdrant.fullname" . }}-'"$SET_INDEX"'.{{ include "qdrant.fullname" . }}-headless:6335'
     fi
     {{ end }}
   production.yaml: |

--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -76,7 +76,7 @@ spec:
             - name: {{ .name }}
               value: {{ .value | quote }}
           {{- end }}
-          command: ["/bin/sh", "-c"]
+          command: ["/bin/bash", "-c"]
           {{- with .Values.args }}
           args:
             {{- toYaml . | nindent 10 }}
@@ -233,12 +233,11 @@ spec:
         {{- toYaml . | nindent 10 }}
         {{- end }}
       spec:
-        storageClassName: {{ .Values.persistence.storageClassName }} 
+        storageClassName: {{ .Values.persistence.storageClassName }}
         accessModes:
         {{- range .Values.persistence.accessModes }}
           - {{ . | quote }}
         {{- end }}
         resources:
           requests:
-            storage: {{ .Values.persistence.size | quote }} 
-         
+            storage: {{ .Values.persistence.size | quote }}

--- a/test/integration/default_installation.bats
+++ b/test/integration/default_installation.bats
@@ -21,3 +21,11 @@ setup_file() {
     [[ "${output}" =~ .*INFO.* ]]
     [[ ! "${output}" =~ .*ERR.* ]]
 }
+
+@test "SIGTERM signals are propagated to qdrant" {
+    run kubectl rollout restart sts/qdrant -n qdrant-helm-integration
+    [ $status -eq 0 ]
+    # If signals aren't working, this will take >30 seconds and time out
+    run kubectl rollout status statefulset qdrant -n qdrant-helm-integration --timeout=15s
+    [ $status -eq 0 ]
+}


### PR DESCRIPTION
Currently, when you delete a qdrant pod right now, it will take the full terminationGracePeriodSeconds and then get SIGKILLed.

I was originally thinking I had to do what I did in #90, but apparently just using `/bin/bash` instead of `/bin/sh` (which just points to `/bin/dash` in our debian image) fixes the signal propagation to the `exec`'d process. Apparently the two shells handle signals slightly differently from each other.