### PR TITLE
Make annotations for the ServiceAccount configurable

### DIFF
--- a/charts/qdrant/templates/serviceaccount.yaml
+++ b/charts/qdrant/templates/serviceaccount.yaml
@@ -2,5 +2,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "qdrant.fullname" . }}
+{{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+{{- end }}
   labels:
     {{- include "qdrant.labels" . | nindent 4 }}

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -172,6 +172,9 @@ metrics:
     ##
     relabelings: []
 
+serviceAccount:
+  annotations: {}
+
 priorityClassName: ""
 
 podDisruptionBudget:


### PR DESCRIPTION
One use-case would be associating a ServiceAccount with an IAM role in EKS (https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html)

Fixes https://github.com/qdrant/qdrant-helm/issues/89