### PR TITLE
Remove extraneous exec in initialize.sh

### DIFF
--- a/charts/qdrant/templates/configmap.yaml
+++ b/charts/qdrant/templates/configmap.yaml
@@ -8,7 +8,7 @@ data:
     SET_INDEX=${HOSTNAME##*-}
     {{- if and (.Values.snapshotRestoration.enabled) (eq (.Values.replicaCount | quote)  (1 | quote)) }}
     echo "Starting initializing for pod $SET_INDEX and snapshots restoration"
-    exec ./entrypoint.sh {{ range .Values.snapshotRestoration.snapshots }} --snapshot {{ . }} {{ end }}
+    ./entrypoint.sh {{ range .Values.snapshotRestoration.snapshots }} --snapshot {{ . }} {{ end }}
     {{- else }}
     echo "Starting initializing for pod $SET_INDEX"
     if [ "$SET_INDEX" = "0" ]; then


### PR DESCRIPTION
Just realized that in #91 I should not have put an `exec` in front of the snapshot restoration step, because it prevents the script from proceeding:

```
$ cat test.sh 
echo "1"
exec echo "2"
exec echo "3"
echo "4"

$ bash test.sh 
1
2
```