### PR TITLE
Fix snapshot restoration and add integration test

### DIFF
--- a/charts/qdrant/templates/configmap.yaml
+++ b/charts/qdrant/templates/configmap.yaml
@@ -8,7 +8,7 @@ data:
     SET_INDEX=${HOSTNAME##*-}
     {{- if and (.Values.snapshotRestoration.enabled) (eq (.Values.replicaCount | quote)  (1 | quote)) }}
     echo "Starting initializing for pod $SET_INDEX and snapshots restoration"
-    ./entrypoint.sh {{ range .Values.snapshotRestoration.snapshots }} --snapshot {{ . }} {{ end }}
+    exec ./entrypoint.sh --uri 'http://{{ include "qdrant.fullname" . }}-0.{{ include "qdrant.fullname" . }}-headless:6335' {{ range .Values.snapshotRestoration.snapshots }} --snapshot {{ . }} {{ end }}
     {{- else }}
     echo "Starting initializing for pod $SET_INDEX"
     if [ "$SET_INDEX" = "0" ]; then

--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -17,7 +17,7 @@ spec:
     metadata:
       annotations:
       {{- if (default .Values.updateConfigurationOnChange false) }}
-        checksum/config: {{ tpl (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       {{- end }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/charts/qdrant/templates/tests/test-db-interaction.yaml
+++ b/charts/qdrant/templates/tests/test-db-interaction.yaml
@@ -43,6 +43,7 @@ data:
     set -xe
     echo 'connect-timeout = 5' > $HOME/.curlrc
     echo 'retry = 5' >> $HOME/.curlrc
+    echo 'retry-all-errors' >> $HOME/.curlrc
 
     if [ -d /mnt/secrets/certs ]; then
       cp /mnt/secrets/certs/ca.pem /usr/share/pki/trust/anchors/private-ca.pem

--- a/test/integration/assets/snapshot-pvc.yaml
+++ b/test/integration/assets/snapshot-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: snapshots-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/test/integration/assets/snapshot-values.yaml
+++ b/test/integration/assets/snapshot-values.yaml
@@ -1,0 +1,6 @@
+updateConfigurationOnChange: true
+snapshotRestoration:
+  enabled: true
+  pvcName: snapshots-pvc
+  # To be supplied via --set
+  snapshots: []

--- a/test/integration/snapshot_restore.bats
+++ b/test/integration/snapshot_restore.bats
@@ -1,0 +1,26 @@
+# Inspired by https://github.com/qdrant/qdrant/blob/v1.6.1/tests/snapshots/snapshots-recovery.sh
+
+QDRANT_URL="http://qdrant.qdrant-helm-integration:6333"
+
+setup_file() {
+    # Create the PVC, then helm upgrade with no snapshots so that the PVC gets mounted
+    kubectl apply -f test/integration/assets/snapshot-pvc.yaml -n qdrant-helm-integration
+    helm upgrade --install qdrant charts/qdrant -n qdrant-helm-integration -f test/integration/assets/snapshot-values.yaml --set snapshotRestoration.snapshots=null --wait
+    kubectl rollout status statefulset qdrant -n qdrant-helm-integration
+}
+
+
+@test "snapshot restoration works" {
+    # Create the test data and create a snapshot
+    helm test qdrant -n qdrant-helm-integration --logs
+    SNAPSHOT_NAME=$(kubectl exec -n default curl -- curl -X POST "$QDRANT_URL/collections/test_collection/snapshots" | grep -o 'test_collection.*\.snapshot')
+
+    # Delete the collection, then restore
+    kubectl exec -n default curl -- curl -X DELETE "$QDRANT_URL/collections/test_collection?wait"
+    helm upgrade --install qdrant charts/qdrant -n qdrant-helm-integration -f test/integration/assets/snapshot-values.yaml --set snapshotRestoration.snapshots="{/qdrant/snapshots/test_collection/$SNAPSHOT_NAME\:test_collection}" --wait
+    kubectl rollout status statefulset qdrant -n qdrant-helm-integration
+
+    run kubectl exec -n default curl -- curl -s $QDRANT_URL/collections/test_collection/points/6 --fail-with-body
+    [ $status -eq 0 ]
+    [[ "${output}" =~ .*\"Mumbai\".* ]]
+}


### PR DESCRIPTION
Turns out that #93 wasn't needed because we do actually want the `exec`. I thought `--snapshot` made the qdrant command exit or something.

While testing, I also found that we need to supply the `--url` flag, otherwise the pod may crash with raft errors.

After restoring the snapshot, there is still a strange warning message: `Failed to apply collection meta operation: Collection test_collection already exists!`. This appears harmless since the data does get restored, but strange nonetheless.