### PR TITLE
Fix: Publish DNS for not-ready pods via the headless service

### DIFF
--- a/charts/qdrant/templates/service-headless.yaml
+++ b/charts/qdrant/templates/service-headless.yaml
@@ -9,6 +9,7 @@ metadata:
 {{- end }}
 spec:
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
     {{- range .Values.service.ports }}
     - name: {{ .name }}


### PR DESCRIPTION
For clustering/discovery purpose, we use the headless service of the StatefulSet today. It'll provide a DNS entry for every pod of the StatefulSet. Qdrant pods use this specific DNS name as --uri, so that's what's communicated to each peer. By default the service will only provide DNS name when the pod is ready. So if a pod is not ready, other peers cannot reach it. But we should change the service to always provide DNS for a pod, regardless it's readiness, using .spec.publishNotReadyAddresses=true to allow cluster-internal traffic.