### PR TITLE
Fix: Add preStop hook to allow graceful network shutdown

### DIFF
--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -157,6 +157,10 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "3"]
           volumeMounts:
           - name: qdrant-storage
             mountPath: /qdrant/storage


### PR DESCRIPTION
Adding a preStop sleep to allow other controllers to remove the pod from the network path. Without, there's a risk of breaking in-flight requests when the container is already stopped but the endpoints/endpointsSlice objects haven't been updated.

Source:  https://learnk8s.io/graceful-shutdown