### PR TITLE
Use /readyz for 1.7.3 onwards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ lint:
 	helm lint charts/qdrant
 
 test-unit:
-	go test -v ./test
+	go test ./test
 
 test-integration:
-	bats test/integration --verbose-run --show-output-of-passing-tests
+	bats test/integration
 
 test-unit-lint:
 	gofmt -w -s ./test

--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -9,6 +9,7 @@ metadata:
 {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  podManagementPolicy: Parallel
   selector:
     matchLabels:
       {{- include "qdrant.selectorLabels" . | nindent 6 }}
@@ -118,7 +119,7 @@ spec:
             {{- end }}
             {{- if eq .name "http"}}
             httpGet:
-              path: /
+              path: "{{- if semverCompare ">=1.7.3" ($.Values.image.tag | default $.Chart.AppVersion) -}}/readyz{{else}}/{{end}}"
               port: {{ .targetPort }}
               {{- if and $values.config.service $values.config.service.enable_tls }}
               scheme: HTTPS

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: qdrant/qdrant
+  repository: docker.io/qdrant/qdrant
   pullPolicy: IfNotPresent
   tag: ""
   useUnprivilegedImage: false

--- a/test/integration/multi_node_installation.bats
+++ b/test/integration/multi_node_installation.bats
@@ -1,0 +1,16 @@
+@test "Rolling update" {
+  run kubectl rollout restart sts/qdrant -n distributed-update-test
+  [ $status -eq 0 ]
+}
+
+setup() {
+  # Using a custom namespace to avoid side effects with other tests
+  kubectl create ns distributed-update-test
+  helm upgrade --install qdrant charts/qdrant -n distributed-update-test --wait --timeout 3m --set replicaCount=3 --set image.tag=v1.7.3
+  kubectl rollout status statefulset qdrant -n distributed-update-test
+}
+
+teardown() {
+  helm uninstall qdrant -n distributed-update-test
+  kubectl delete ns distributed-update-test
+}

--- a/test/integration/setup_suite.bash
+++ b/test/integration/setup_suite.bash
@@ -1,7 +1,7 @@
 setup_suite() {
     kind create cluster -n qdrant-helm-integration
     kubectl create serviceaccount default -n default
-    kubectl -n default run curl --image=curlimages/curl --command -- sh -c "sleep 3600"
+    kubectl -n default run curl --image=docker.io/curlimages/curl --command -- sh -c "sleep 3600"
     kubectl wait --for=condition=Ready pod/curl -n default --timeout=300s
     kubectl create namespace qdrant-helm-integration
     kubectl create serviceaccount default -n qdrant-helm-integration || true

--- a/test/qdrant_image_test.go
+++ b/test/qdrant_image_test.go
@@ -1,14 +1,15 @@
 package test
 
 import (
-	"github.com/ghodss/yaml"
-	"github.com/samber/lo"
-	corev1 "k8s.io/api/core/v1"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -67,7 +68,7 @@ func TestOverwriteImage(t *testing.T) {
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"image.tag":                  "test-tag",
+			"image.tag":                  "v1.6.0",
 			"image.repository":           "test/repo",
 			"image.useUnprivilegedImage": "true",
 		},
@@ -83,5 +84,5 @@ func TestOverwriteImage(t *testing.T) {
 		return container.Name == "qdrant"
 	})
 
-	require.Equal(t, "test/repo:test-tag-unprivileged", container.Image)
+	require.Equal(t, "test/repo:v1.6.0-unprivileged", container.Image)
 }

--- a/test/qdrant_probes_test.go
+++ b/test/qdrant_probes_test.go
@@ -1,11 +1,12 @@
 package test
 
 import (
-	"github.com/samber/lo"
-	corev1 "k8s.io/api/core/v1"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -25,20 +26,47 @@ func TestDefaultProbesOnStatefulset(t *testing.T) {
 	namespaceName := "qdrant-" + strings.ToLower(random.UniqueId())
 	logger.Log(t, "Namespace: %s\n", namespaceName)
 
-	options := &helm.Options{
-		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	tests := []struct {
+		version           string
+		readynessEndpoint string
+	}{
+		{
+			version:           "v1.6.0",
+			readynessEndpoint: "/",
+		},
+		{
+			version:           "v1.7.3",
+			readynessEndpoint: "/readyz",
+		},
+		{
+			version:           "v1.7.4",
+			readynessEndpoint: "/readyz",
+		},
 	}
 
-	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/statefulset.yaml"})
+	for _, test := range tests {
+		t.Run("/readyz with "+test.version, func(t *testing.T) {
+			options := &helm.Options{
+				SetValues: map[string]string{
+					"image.tag":                  test.version,
+					"image.repository":           "test/repo",
+					"image.useUnprivilegedImage": "true",
+				},
+				KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+			}
 
-	var statefulSet appsv1.StatefulSet
-	helm.UnmarshalK8SYaml(t, output, &statefulSet)
+			output := helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/statefulset.yaml"})
 
-	container, _ := lo.Find(statefulSet.Spec.Template.Spec.Containers, func(container corev1.Container) bool {
-		return container.Name == "qdrant"
-	})
+			var statefulSet appsv1.StatefulSet
+			helm.UnmarshalK8SYaml(t, output, &statefulSet)
 
-	require.Empty(t, container.StartupProbe)
-	require.Equal(t, "/", container.ReadinessProbe.HTTPGet.Path)
-	require.Empty(t, container.LivenessProbe)
+			container, _ := lo.Find(statefulSet.Spec.Template.Spec.Containers, func(container corev1.Container) bool {
+				return container.Name == "qdrant"
+			})
+
+			require.Empty(t, container.StartupProbe)
+			require.Equal(t, test.readynessEndpoint, container.ReadinessProbe.HTTPGet.Path)
+			require.Empty(t, container.LivenessProbe)
+		})
+	}
 }


### PR DESCRIPTION
The /readyz endpoints only reports success when all sharts on the node have been fully replicated. This ensures availability during a rolling update.

This functionality was tested by continously restarting a StatefulSet for 1h, while running bfb against the cluster. Testing manifests can be found in https://github.com/qdrant/qdrant-helm/tree/update-validation