### PR TITLE
Fix metrics scraping if api key is enabled

### DIFF
--- a/charts/qdrant/templates/servicemonitor.yaml
+++ b/charts/qdrant/templates/servicemonitor.yaml
@@ -24,6 +24,13 @@ spec:
       relabelings:
 {{ tpl (toYaml .Values.metrics.serviceMonitor.relabelings | indent 8) . }}
 {{- end }}
+{{- if .Values.apiKey }}
+      authorization:
+        type: Bearer
+        credentials:
+          name: {{ include "qdrant.fullname" . }}-apikey
+          key: api-key
+{{- end }}
   selector:
     matchLabels:
       {{- include "qdrant.labels" . | nindent 6 }}


### PR DESCRIPTION
Authorization is needed to scrape the /metrics endpoint when qdrant is secured with api key.