### PR TITLE
fix: typos in service template

### DIFF
--- a/charts/qdrant/templates/service.yaml
+++ b/charts/qdrant/templates/service.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   type: {{ .Values.service.type | default "ClusterIP" }}
   {{- if .Values.service.loadBalancerIP }}
-    loadBalancerIP: { .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
   ports:
     {{- range .Values.service.ports }}


### PR DESCRIPTION
This commit fixes a typo in the service template. The loadBalancerIP field was not properly formatted and was causing the chart to fail when that value was set.