### PR TITLE
allow configurable podManagementPolicy

### DIFF
--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -9,7 +9,7 @@ metadata:
 {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
-  podManagementPolicy: Parallel
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
   selector:
     matchLabels:
       {{- include "qdrant.selectorLabels" . | nindent 6 }}

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -176,6 +176,8 @@ serviceAccount:
 
 priorityClassName: ""
 
+podManagementPolicy: Parallel
+
 podDisruptionBudget:
   enabled: false
   maxUnavailable: 1


### PR DESCRIPTION
Ran into https://github.com/qdrant/qdrant-helm/issues/139 myself today.
This should allow those of us on the old `OrderedReady` policy to upgrade without needing to rebuild our statefulsets while retaining the new default policy of `Parallel`.