### PR TITLE
Support storing snapshots in a separate PVC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+## Running tests
+
+This repository has unit and integration tests for the charts. All charts are also linted.
+
+### Linting
+
+Linting is done with `helm lint`.
+
+Prerequisites:
+
+* Helm
+
+```bash
+brew install helm
+```
+
+To lint all charts:
+
+```bash
+make lint
+```
+
+### Unit tests
+
+Unit tests are in the `./test` directory and written in Go with [terratest](https://github.com/gruntwork-io/terratest).
+
+Prerequisites:
+
+* Go
+
+```bash
+brew install go
+```
+
+To run the tests:
+
+```bash
+make test-unit
+```
+
+### Integration tests
+
+Integration tests are in the `./test/integration` directory and written with [bats](https://bats-core.readthedocs.io/).
+
+There is an additional simple Helm test in `./charts/qdrant/templates/tests`.
+
+Prerequisites:
+
+* Docker
+* Kind
+* Kubectl
+* Helm
+* Bats
+
+```bash
+brew install helm kubectl kind bats-core homebrew/cask/docker
+```
+
+To run the tests:
+
+```bash
+make test-integration
+```
+
+## Releasing
+
+Generally, we choose to release a new chart when there are important new releases to Qdrant or important chart-related changes.
+
+1. Check the release notes of [qdrant/qdrant](https://github.com/qdrant/qdrant/releases) to see if any environment variables or other settings need to be adjusted.
+2. Sync your local clone/fork of the [qdrant-helm](https://github.com/qdrant/qdrant-helm) repo: `git checkout main && git pull`
+3. Checkout a new feature branch: `git checkout -b feat/<name>/qdrant-<version>`
+4. Edit `Chart.yaml` to bump the appVersion and chartVersion.
+5. Edit `Chart.yaml` to update `artifacthub.io/changes` to mention the new changes.
+6. Edit `charts/CHANGELOG.md` to mention the same changes
+7. Edit the root `CHANGELOG.md` to mention the same changes
+    1. Why so many changelog changes? Each changelog file is for a different audience (artifacthub, chart browsing, github browsing). This could be automated in the future.
+8. Push your changes to GitHub and create a pull request. This allows the integration tests to run.
+
+As soon as these changes are merged to main, there is a [github action that detects changes to Chart.yaml](https://github.com/qdrant/qdrant-helm/blob/cea92d092ac330493147536e27f3edeb465ffe75/.github/workflows/release-workflow.yaml#L7) which will perform the remainder of the release operations (creating a github release, publishing the helm chart, updating index.html for the [github pages site](https://qdrant.github.io/qdrant-helm/), etc.)

--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -40,28 +40,26 @@ spec:
       initContainers:
       {{- if .Values.updateVolumeFsOwnership }}
       {{- if and .Values.containerSecurityContext .Values.containerSecurityContext.runAsUser }}
-      - name: ensure-storage-dir-ownership
+      - name: ensure-dir-ownership
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         command:
           - chown
           - -R
           - {{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}
           - /qdrant/storage
+          - /qdrant/snapshots
+          {{- if and .Values.snapshotRestoration.enabled .Values.snapshotRestoration.pvcName }}
+          - {{ .Values.snapshotRestoration.mountPath }}
+          {{- end }}
         volumeMounts:
           - name: qdrant-storage
             mountPath: /qdrant/storage
-      {{- if .Values.snapshotRestoration.enabled }}
-      - name: ensure-snapshots-dir-ownership
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-        command:
-          - chown
-          - -R
-          - {{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}
-          - /qdrant/snapshots
-        volumeMounts:
           - name: qdrant-snapshots
             mountPath: /qdrant/snapshots
-      {{- end }}
+          {{- if and .Values.snapshotRestoration.enabled .Values.snapshotRestoration.pvcName }}
+          - name: qdrant-snapshot-restoration
+            mountPath: {{ .Values.snapshotRestoration.mountPath }}
+          {{- end }}
       {{- end }}
       {{- end }}
       containers:
@@ -177,6 +175,10 @@ spec:
             mountPath: /qdrant/config/local.yaml
             subPath: local.yaml
           {{- end }}
+          {{- if and .Values.snapshotRestoration.enabled .Values.snapshotRestoration.pvcName }}
+          - name: qdrant-snapshot-restoration
+            mountPath: {{ .Values.snapshotRestoration.mountPath }}
+          {{- end }}
           - name: qdrant-snapshots
             mountPath: /qdrant/snapshots
           - name: qdrant-init
@@ -210,11 +212,12 @@ spec:
           configMap:
             name: {{ include "qdrant.fullname" . }}
             defaultMode: 0755
-        {{- if .Values.snapshotRestoration.enabled }}
-        - name: qdrant-snapshots
+        {{- if and .Values.snapshotRestoration.enabled .Values.snapshotRestoration.pvcName }}
+        - name: qdrant-snapshot-restoration
           persistentVolumeClaim:
             claimName: {{ .Values.snapshotRestoration.pvcName }}
-        {{- else }}
+        {{- end }}
+        {{- if not .Values.snapshotPersistence.enabled }}
         - name: qdrant-snapshots
           emptyDir: {}
         {{- end }}
@@ -247,3 +250,22 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistence.size | quote }}
+    {{- if .Values.snapshotPersistence.enabled }}
+    - metadata:
+        name: qdrant-snapshots
+        labels:
+          app: {{ template "qdrant.name" . }}
+        {{- with .Values.snapshotPersistence.annotations }}
+        annotations:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        storageClassName: {{ .Values.snapshotPersistence.storageClassName }}
+        accessModes:
+        {{- range .Values.snapshotPersistence.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.snapshotPersistence.size | quote }}
+    {{- end }}

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -130,12 +130,26 @@ persistence:
   annotations: {}
   # storageClassName: local-path
 
-# only supported for single node qdrant clusters.
+# If you use snapshots or the snapshot shard transfer mechanism, we recommend
+# creating a separate volume of the same size as your main volume so that your
+# cluster won't crash if the snapshot is too big.
+snapshotPersistence:
+  enabled: false
+  accessModes: ["ReadWriteOnce"]
+  size: 10Gi
+  annotations: {}
+  # You can change the storageClassName to ensure snapshots are saved to cold storage.
+  # storageClassName: local-path
+
 snapshotRestoration:
   enabled: false
+  # Set pvcName if you want to restore from a separately-created PVC. Only supported for single-node clusters unless the PVC is ReadWriteMany.
+  # If you set snapshotPersistence.enabled and want to restore a snapshot from there, you can leave this blank to skip mounting an external volume.
   pvcName: snapshots-pvc
+  # Must not conflict with /qdrant/snapshots or /qdrant/storage
+  mountPath: /qdrant/snapshot-restoration
   snapshots:
-  #  - /qdrant/snapshots/test_collection/test_collection-2022-10-24-13-56-50.snapshot:test_collection
+  #  - /qdrant/snapshot-restoration/test_collection/test_collection-2022-10-24-13-56-50.snapshot:test_collection
 
 # modification example for configuration to overwrite defaults
 config:

--- a/test/integration/assets/snapshot-persistence-values.yaml
+++ b/test/integration/assets/snapshot-persistence-values.yaml
@@ -1,0 +1,11 @@
+snapshotPersistence:
+  enabled: true
+
+snapshotRestoration:
+  # Remove the PVC name since we will be restoring from the built-in PVC
+  pvcName: ""
+
+config:
+  storage:
+    # Override snapshot-values.yaml back to the default value
+    snapshots_path: /qdrant/snapshots

--- a/test/integration/assets/snapshot-values.yaml
+++ b/test/integration/assets/snapshot-values.yaml
@@ -4,3 +4,9 @@ snapshotRestoration:
   pvcName: snapshots-pvc
   # To be supplied via --set
   snapshots: []
+
+config:
+  storage:
+    # We override this so that we can easily save a snapshot in here
+    # directly without having to move the file around in our test
+    snapshots_path: /qdrant/snapshot-restoration

--- a/test/integration/snapshot_persistence.bats
+++ b/test/integration/snapshot_persistence.bats
@@ -1,0 +1,28 @@
+QDRANT_URL="http://qdrant.qdrant-helm-integration:6333"
+
+setup_file() {
+    helm upgrade --install qdrant charts/qdrant -n qdrant-helm-integration -f test/integration/assets/snapshot-persistence-values.yaml --wait
+    kubectl rollout status statefulset qdrant -n qdrant-helm-integration
+}
+
+
+@test "snapshot persistence works" {
+    # Create the test data and create a snapshot
+    helm test qdrant -n qdrant-helm-integration --logs
+    SNAPSHOT_NAME=$(kubectl exec -n default curl -- curl -X POST "$QDRANT_URL/collections/test_collection/snapshots" | grep -o 'test_collection.*\.snapshot')
+
+    # Delete the collection
+    kubectl exec -n default curl -- curl -X DELETE "$QDRANT_URL/collections/test_collection?wait"
+
+    # Restart the cluster
+    kubectl rollout restart statefulset qdrant -n qdrant-helm-integration
+    kubectl rollout status statefulset qdrant -n qdrant-helm-integration
+    # Ensure the snapshot survived the reboot by trying to restore from it
+    helm upgrade qdrant charts/qdrant -n qdrant-helm-integration -f test/integration/assets/snapshot-values.yaml -f test/integration/assets/snapshot-persistence-values.yaml --set snapshotRestoration.snapshots="{/qdrant/snapshots/test_collection/$SNAPSHOT_NAME\:test_collection}" --wait
+    kubectl rollout status statefulset qdrant -n qdrant-helm-integration
+
+    # Ensure the restoration worked
+    run kubectl exec -n default curl -- curl -s $QDRANT_URL/collections/test_collection/points/6 --fail-with-body
+    [ $status -eq 0 ]
+    [[ "${output}" =~ .*\"Mumbai\".* ]]
+}

--- a/test/integration/snapshot_persistence.bats
+++ b/test/integration/snapshot_persistence.bats
@@ -1,6 +1,9 @@
 QDRANT_URL="http://qdrant.qdrant-helm-integration:6333"
 
 setup_file() {
+    # Must delete since this test modifies immutable fields of the STS
+    helm delete qdrant -n qdrant-helm-integration || true
+    kubectl wait --for=delete pod/qdrant-0 -n qdrant-helm-integration --timeout=300s
     helm upgrade --install qdrant charts/qdrant -n qdrant-helm-integration -f test/integration/assets/snapshot-persistence-values.yaml --wait
     kubectl rollout status statefulset qdrant -n qdrant-helm-integration
 }
@@ -25,4 +28,8 @@ setup_file() {
     run kubectl exec -n default curl -- curl -s $QDRANT_URL/collections/test_collection/points/6 --fail-with-body
     [ $status -eq 0 ]
     [[ "${output}" =~ .*\"Mumbai\".* ]]
+}
+
+teardown_file() {
+    helm delete qdrant -n qdrant-helm-integration || true
 }

--- a/test/integration/snapshot_restore.bats
+++ b/test/integration/snapshot_restore.bats
@@ -17,7 +17,7 @@ setup_file() {
 
     # Delete the collection, then restore
     kubectl exec -n default curl -- curl -X DELETE "$QDRANT_URL/collections/test_collection?wait"
-    helm upgrade --install qdrant charts/qdrant -n qdrant-helm-integration -f test/integration/assets/snapshot-values.yaml --set snapshotRestoration.snapshots="{/qdrant/snapshots/test_collection/$SNAPSHOT_NAME\:test_collection}" --wait
+    helm upgrade --install qdrant charts/qdrant -n qdrant-helm-integration -f test/integration/assets/snapshot-values.yaml --set snapshotRestoration.snapshots="{/qdrant/snapshot-restoration/test_collection/$SNAPSHOT_NAME\:test_collection}" --wait
     kubectl rollout status statefulset qdrant -n qdrant-helm-integration
 
     run kubectl exec -n default curl -- curl -s $QDRANT_URL/collections/test_collection/points/6 --fail-with-body


### PR DESCRIPTION
This PR allows users to define a separate `volumeClaimTemplate` for storing snapshots, just like we do in Qdrant Cloud. I designed it to not conflict with the `snapshotRestoration` feature, so I moved that volume to a different mount path.

It's important to be able to have a separate volume for snapshots so that large snapshots or large shard transfer operations that use the snapshot method do not result in the node running out of disk space in the primary PVC. Also most cloud servers have very small local disks (which is where `emptyDir` data is stored), so they need a separate PVC to take any snapshots.