### PR TITLE
feat(statefulset): add containerSecurityContext to init containers

### DIFF
--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -50,6 +50,10 @@ spec:
         volumeMounts:
           - name: qdrant-storage
             mountPath: /qdrant/storage
+        {{- with .Values.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       {{- if .Values.snapshotRestoration.enabled }}
       - name: ensure-snapshots-dir-ownership
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -61,6 +65,10 @@ spec:
         volumeMounts:
           - name: qdrant-snapshots
             mountPath: /qdrant/snapshots
+        {{- with .Values.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       {{- end }}
       {{- end }}
       {{- end }}


### PR DESCRIPTION
The containerSecurityContext is already partially utilized within the init containers. Therefore, it would make sense to extend its application as a securityContext to the initContainers as well.