### PR TITLE
Add both storage and snapshot volume names to values.yaml

### DIFF
--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -52,9 +52,9 @@ spec:
           - {{ .Values.snapshotRestoration.mountPath }}
           {{- end }}
         volumeMounts:
-          - name: qdrant-storage
+          - name: {{ .Values.persistence.storageVolumeName | default "qdrant-storage" }} 
             mountPath: /qdrant/storage
-          - name: qdrant-snapshots
+          - name: {{ .Values.snapshotPersistence.snapshotsVolumeName | default "qdrant-snapshots" }}
             mountPath: /qdrant/snapshots
           {{- if and .Values.snapshotRestoration.enabled .Values.snapshotRestoration.pvcName }}
           - name: qdrant-snapshot-restoration
@@ -162,7 +162,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-          - name: qdrant-storage
+          - name: {{ .Values.persistence.storageVolumeName | default "qdrant-storage" }} 
             mountPath: /qdrant/storage
           - name: qdrant-config
             mountPath: /qdrant/config/initialize.sh
@@ -179,7 +179,7 @@ spec:
           - name: qdrant-snapshot-restoration
             mountPath: {{ .Values.snapshotRestoration.mountPath }}
           {{- end }}
-          - name: qdrant-snapshots
+          - name: {{ .Values.snapshotPersistence.snapshotsVolumeName | default "qdrant-snapshots" }} 
             mountPath: /qdrant/snapshots
           - name: qdrant-init
             mountPath: /qdrant/init
@@ -218,7 +218,7 @@ spec:
             claimName: {{ .Values.snapshotRestoration.pvcName }}
         {{- end }}
         {{- if not .Values.snapshotPersistence.enabled }}
-        - name: qdrant-snapshots
+        - name: {{ .Values.snapshotPersistence.snapshotsVolumeName | default "qdrant-snapshots" }} 
           emptyDir: {}
         {{- end }}
         - name: qdrant-init
@@ -234,7 +234,7 @@ spec:
         {{- end}}
   volumeClaimTemplates:
     - metadata:
-        name: qdrant-storage
+        name: {{ .Values.persistence.storageVolumeName | default "qdrant-storage" }} 
         labels:
           app: {{ template "qdrant.name" . }}
         {{- with .Values.persistence.annotations }}
@@ -252,7 +252,7 @@ spec:
             storage: {{ .Values.persistence.size | quote }}
     {{- if .Values.snapshotPersistence.enabled }}
     - metadata:
-        name: qdrant-snapshots
+        name: {{ .Values.snapshotPersistence.snapshotsVolumeName | default "qdrant-snapshots" }} 
         labels:
           app: {{ template "qdrant.name" . }}
         {{- with .Values.snapshotPersistence.annotations }}

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -128,6 +128,7 @@ persistence:
   accessModes: ["ReadWriteOnce"]
   size: 10Gi
   annotations: {}
+  # storageVolumeName: qdrant-storage
   # storageClassName: local-path
 
 # If you use snapshots or the snapshot shard transfer mechanism, we recommend
@@ -138,6 +139,7 @@ snapshotPersistence:
   accessModes: ["ReadWriteOnce"]
   size: 10Gi
   annotations: {}
+  # snapshotsVolumeName: qdrant-snapshots
   # You can change the storageClassName to ensure snapshots are saved to cold storage.
   # storageClassName: local-path
 


### PR DESCRIPTION
While configuring qdrant deployment we uncover the requirement to parametrize volume names (due to requirements from our infra).
This PR adds both storage and snapshot volume names parameters.