### PR TITLE
Update to v1.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-0.9.4](https://github.com/qdrant/qdrant-helm/tree/qdrant-0.9.4) (2024-06-25)
+
+- Update Qdrant to v1.9.7
+
 ## [qdrant-0.9.3](https://github.com/qdrant/qdrant-helm/tree/qdrant-0.9.3) (2024-06-22)
 
 - Update Qdrant to v1.9.6

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [qdrant-0.9.3](https://github.com/qdrant/qdrant-helm/tree/qdrant-0.9.3) (2024-06-22)
+## [qdrant-0.9.4](https://github.com/qdrant/qdrant-helm/tree/qdrant-0.9.4) (2024-06-25)
 
-- Update Qdrant to v1.9.6
+- Update Qdrant to v1.9.7
 
 For the full changelog, see [CHANGELOG.md](https://github.com/qdrant/qdrant-helm/blob/main/CHANGELOG.md).
 

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,10 +13,10 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 0.9.3
-appVersion: v1.9.6
+version: 0.9.4
+appVersion: v1.9.7
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
     - kind: added
-      description: Update Qdrant to v1.9.6
+      description: Update Qdrant to v1.9.7


### PR DESCRIPTION
This updates the Helm chart to [Qdrant 1.9.7](https://github.com/qdrant/qdrant/releases/tag/v1.9.7).

This bump is important because previous versions can cause a crash loop with sparse vector indices.

I'm not too familiar with Helm, and just followed the pattern from <https://github.com/qdrant/qdrant-helm/pull/197>. So please review with care :smile: 