### PR TITLE
Update to v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-0.10.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-0.10.0) (2024-07-02)
+
+- Update Qdrant to v1.10.0
+
 ## [qdrant-0.9.4](https://github.com/qdrant/qdrant-helm/tree/qdrant-0.9.4) (2024-06-25)
 
 - Update Qdrant to v1.9.7

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [qdrant-0.9.4](https://github.com/qdrant/qdrant-helm/tree/qdrant-0.9.4) (2024-06-25)
+## [qdrant-0.10.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-0.10.0) (2024-07-02)
 
-- Update Qdrant to v1.9.7
+- Update Qdrant to v1.10.0
 
 For the full changelog, see [CHANGELOG.md](https://github.com/qdrant/qdrant-helm/blob/main/CHANGELOG.md).
 

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,10 +13,10 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 0.9.4
-appVersion: v1.9.7
+version: 0.10.0
+appVersion: v1.10.0
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
     - kind: added
-      description: Update Qdrant to v1.9.7
+      description: Update Qdrant to v1.10.0


### PR DESCRIPTION
This updates the Helm chart to [Qdrant 1.10.0](https://github.com/qdrant/qdrant/releases/tag/v1.10.0).

Follows the pattern of <https://github.com/qdrant/qdrant-helm/pull/198>.

Please review with care, as I haven't tested the new Chart.