### PR TITLE
Update to v1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-0.10.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-0.10.1) (2024-07-18)
+
+- Update Qdrant to v1.10.1
+
 ## [qdrant-0.10.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-0.10.0) (2024-07-02)
 
 - Update Qdrant to v1.10.0

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [qdrant-0.10.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-0.10.0) (2024-07-02)
+## [qdrant-0.10.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-0.10.1) (2024-07-18)
 
-- Update Qdrant to v1.10.0
+- Update Qdrant to v1.10.1
 
 For the full changelog, see [CHANGELOG.md](https://github.com/qdrant/qdrant-helm/blob/main/CHANGELOG.md).
 

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,10 +13,10 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 0.10.0
-appVersion: v1.10.0
+version: 0.10.1
+appVersion: v1.10.1
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
     - kind: added
-      description: Update Qdrant to v1.10.0
+      description: Update Qdrant to v1.10.1


### PR DESCRIPTION
This updates the Helm chart to [Qdrant 1.10.1](https://github.com/qdrant/qdrant/releases/tag/v1.10.1).

Follows the pattern of <https://github.com/qdrant/qdrant-helm/pull/201>.

Please review with care, as I haven't tested the new Chart.