### PR TITLE
Apply additional label to headless Service + ServiceMonitor to avoid duplicate scraping

### DIFF
--- a/charts/qdrant/templates/service-headless.yaml
+++ b/charts/qdrant/templates/service-headless.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "qdrant.fullname" . }}-headless
   labels:
     {{- include "qdrant.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-discovery
 {{- with .Values.service.additionalLabels }}
 {{- toYaml . | nindent 4 }}
 {{- end }}

--- a/charts/qdrant/templates/servicemonitor.yaml
+++ b/charts/qdrant/templates/servicemonitor.yaml
@@ -40,4 +40,5 @@ spec:
   selector:
     matchLabels:
       {{- include "qdrant.labels" . | nindent 6 }}
+      app.kubernetes.io/component: cluster-discovery
 {{- end }}


### PR DESCRIPTION
Add a common label `app.kubernetes.io/component` (https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels) with value `cluster-discovery` to the headless Service and the ServiceMonitor it's ensured metrics are only scraped once.

Using the headless service also makes the most sense, as it has the sole purpose of discovering all Pods making up a qdrant cluster. With `publishNotReadyAddresses: true` metrics are also collected from non-ready pods, see https://github.com/prometheus-operator/prometheus-operator/discussions/5693. This is helpful to also collect metrics from Pods that might never become ready to use them for e.g. alerting and problem analysis

Fixes: #207