### PR TITLE
ServiceMonitor: Prefer read-only api-key

### DIFF
--- a/charts/qdrant/templates/servicemonitor.yaml
+++ b/charts/qdrant/templates/servicemonitor.yaml
@@ -24,18 +24,18 @@ spec:
       relabelings:
 {{ tpl (toYaml .Values.metrics.serviceMonitor.relabelings | indent 8) . }}
 {{- end }}
-{{- if .Values.apiKey }}
-      authorization:
-        type: Bearer
-        credentials:
-          name: {{ include "qdrant.fullname" . }}-apikey
-          key: api-key
-{{- else if .Values.readOnlyApiKey }}
+{{- if .Values.readOnlyApiKey }}
       authorization:
         type: Bearer
         credentials:
           name: {{ include "qdrant.fullname" . }}-apikey
           key: read-only-api-key
+{{- else if .Values.apiKey }}
+      authorization:
+        type: Bearer
+        credentials:
+          name: {{ include "qdrant.fullname" . }}-apikey
+          key: api-key
 {{- end }}
   selector:
     matchLabels:


### PR DESCRIPTION
When both `apiKey` and `readOnlyApiKey` are `true`, prefer the
read-only key as it is sufficient for scraping the metrics.

Fixes #219
