### PR TITLE
added support for inter-cluster tls and changing the inter-cluster port numbers

### DIFF
--- a/charts/qdrant/templates/_helpers.tpl
+++ b/charts/qdrant/templates/_helpers.tpl
@@ -100,7 +100,7 @@ local.yaml: {{ printf "service:\n  read_only_api_key: %s" $readOnlyApiKey | b64e
 {{/*
 Protocol to use for inter cluster communication
 */}}
-{{- define "qdrant.protocol" -}}
+{{- define "qdrant.p2p.protocol" -}}
 {{ if eq (.Values.config.cluster.p2p.enable_tls | toJson) "true" -}}
 https
 {{- else -}}
@@ -111,6 +111,6 @@ http
 {{/*
 Port to use for inter cluster communication
 */}}
-{{- define "qdrant.port" -}}
+{{- define "qdrant.p2p.port" -}}
 {{- default 6335 .Values.config.cluster.p2p.port -}}
 {{- end -}}

--- a/charts/qdrant/templates/_helpers.tpl
+++ b/charts/qdrant/templates/_helpers.tpl
@@ -96,3 +96,21 @@ read-only-api-key: {{ $readOnlyApiKey | b64enc }}
 local.yaml: {{ printf "service:\n  read_only_api_key: %s" $readOnlyApiKey | b64enc }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Protocol to use for inter cluster communication
+*/}}
+{{- define "qdrant.protocol" -}}
+{{ if eq (.Values.config.cluster.p2p.enable_tls | toJson) "true" -}}
+https
+{{- else -}}
+http
+{{- end -}}
+{{- end -}}
+
+{{/*
+Port to use for inter cluster communication
+*/}}
+{{- define "qdrant.port" -}}
+{{- default 6335 .Values.config.cluster.p2p.port -}}
+{{- end -}}

--- a/charts/qdrant/templates/configmap.yaml
+++ b/charts/qdrant/templates/configmap.yaml
@@ -10,13 +10,13 @@ data:
     SET_INDEX=${HOSTNAME##*-}
     {{- if and (.Values.snapshotRestoration.enabled) (eq (.Values.replicaCount | quote)  (1 | quote)) }}
     echo "Starting initializing for pod $SET_INDEX and snapshots restoration"
-    exec ./entrypoint.sh --uri 'http://{{ include "qdrant.fullname" . }}-0.{{ include "qdrant.fullname" . }}-headless:6335' {{ range .Values.snapshotRestoration.snapshots }} --snapshot {{ . }} {{ end }}
+    exec ./entrypoint.sh --uri '{{ include "qdrant.protocol" . }}://{{ include "qdrant.fullname" . }}-0.{{ include "qdrant.fullname" . }}-headless:{{ include "qdrant.port" . }}' {{ range .Values.snapshotRestoration.snapshots }} --snapshot {{ . }} {{ end }}
     {{- else }}
     echo "Starting initializing for pod $SET_INDEX"
     if [ "$SET_INDEX" = "0" ]; then
-      exec ./entrypoint.sh --uri 'http://{{ include "qdrant.fullname" . }}-0.{{ include "qdrant.fullname" . }}-headless:6335'
+      exec ./entrypoint.sh --uri '{{ include "qdrant.protocol" . }}://{{ include "qdrant.fullname" . }}-0.{{ include "qdrant.fullname" . }}-headless:{{ include "qdrant.port" . }}'
     else
-      exec ./entrypoint.sh --bootstrap 'http://{{ include "qdrant.fullname" . }}-0.{{ include "qdrant.fullname" . }}-headless:6335' --uri 'http://{{ include "qdrant.fullname" . }}-'"$SET_INDEX"'.{{ include "qdrant.fullname" . }}-headless:6335'
+      exec ./entrypoint.sh --bootstrap '{{ include "qdrant.protocol" . }}://{{ include "qdrant.fullname" . }}-0.{{ include "qdrant.fullname" . }}-headless:{{ include "qdrant.port" . }}' --uri '{{ include "qdrant.protocol" . }}://{{ include "qdrant.fullname" . }}-'"$SET_INDEX"'.{{ include "qdrant.fullname" . }}-headless:{{ include "qdrant.port" . }}'
     fi
     {{ end }}
   production.yaml: |

--- a/charts/qdrant/templates/configmap.yaml
+++ b/charts/qdrant/templates/configmap.yaml
@@ -10,13 +10,13 @@ data:
     SET_INDEX=${HOSTNAME##*-}
     {{- if and (.Values.snapshotRestoration.enabled) (eq (.Values.replicaCount | quote)  (1 | quote)) }}
     echo "Starting initializing for pod $SET_INDEX and snapshots restoration"
-    exec ./entrypoint.sh --uri '{{ include "qdrant.protocol" . }}://{{ include "qdrant.fullname" . }}-0.{{ include "qdrant.fullname" . }}-headless:{{ include "qdrant.port" . }}' {{ range .Values.snapshotRestoration.snapshots }} --snapshot {{ . }} {{ end }}
+    exec ./entrypoint.sh --uri '{{ include "qdrant.p2p.protocol" . }}://{{ include "qdrant.fullname" . }}-0.{{ include "qdrant.fullname" . }}-headless:{{ include "qdrant.p2p.port" . }}' {{ range .Values.snapshotRestoration.snapshots }} --snapshot {{ . }} {{ end }}
     {{- else }}
     echo "Starting initializing for pod $SET_INDEX"
     if [ "$SET_INDEX" = "0" ]; then
-      exec ./entrypoint.sh --uri '{{ include "qdrant.protocol" . }}://{{ include "qdrant.fullname" . }}-0.{{ include "qdrant.fullname" . }}-headless:{{ include "qdrant.port" . }}'
+      exec ./entrypoint.sh --uri '{{ include "qdrant.p2p.protocol" . }}://{{ include "qdrant.fullname" . }}-0.{{ include "qdrant.fullname" . }}-headless:{{ include "qdrant.p2p.port" . }}'
     else
-      exec ./entrypoint.sh --bootstrap '{{ include "qdrant.protocol" . }}://{{ include "qdrant.fullname" . }}-0.{{ include "qdrant.fullname" . }}-headless:{{ include "qdrant.port" . }}' --uri '{{ include "qdrant.protocol" . }}://{{ include "qdrant.fullname" . }}-'"$SET_INDEX"'.{{ include "qdrant.fullname" . }}-headless:{{ include "qdrant.port" . }}'
+      exec ./entrypoint.sh --bootstrap '{{ include "qdrant.p2p.protocol" . }}://{{ include "qdrant.fullname" . }}-0.{{ include "qdrant.fullname" . }}-headless:{{ include "qdrant.p2p.port" . }}' --uri '{{ include "qdrant.p2p.protocol" . }}://{{ include "qdrant.fullname" . }}-'"$SET_INDEX"'.{{ include "qdrant.fullname" . }}-headless:{{ include "qdrant.p2p.port" . }}'
     fi
     {{ end }}
   production.yaml: |

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -172,6 +172,7 @@ config:
     enabled: true
     p2p:
       port: 6335
+      enable_tls: false
     consensus:
       tick_period_ms: 100
 


### PR DESCRIPTION
This PR adds 2 new helper variables for the p2p protocol and port.
These are then used when templating `initialize.sh` in `/charts/qdrant/templates/configmap.yaml`
Fixes #222 

Any advice or feedback would be very appreciated as I'm new to open source contributing. :)