### PR TITLE
Update to v1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.11.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.11.1) (2024-08-27)
+
+- Update Qdrant to v1.11.1
+
 ## [qdrant-1.11.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.11.0) (2024-08-12)
 
 - Update Qdrant to v1.11.0

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,10 +1,8 @@
 # Changelog
 
-## [qdrant-1.11.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.11.0) (2024-08-12)
+## [qdrant-1.11.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.11.1) (2024-08-27)
 
-- Update Qdrant to v1.11.0
-- Apply additional label to headless Service + ServiceMonitor to avoid duplicate scraping [#214](https://github.com/qdrant/qdrant-helm/pull/214)
-- Apply tpl() to affinity values to enable reuse of helpers / labels [#213](https://github.com/qdrant/qdrant-helm/pull/213)
+- Update Qdrant to v1.11.1
 
 For the full changelog, see [CHANGELOG.md](https://github.com/qdrant/qdrant-helm/blob/main/CHANGELOG.md).
 

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,20 +13,10 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 1.11.0
-appVersion: v1.11.0
+version: 1.11.1
+appVersion: v1.11.1
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
     - kind: added
-      description: Update Qdrant to v1.11.0
-    - kind: fixed
-      description: Apply additional label to headless Service + ServiceMonitor to avoid duplicate scraping
-      links:
-        - name: Github Issue
-          url: https://github.com/qdrant/qdrant-helm/pull/214
-    - kind: added
-      description: Apply tpl() to affinity values to enable reuse of helpers / labels
-      links:
-        - name: Github Issue
-          url: https://github.com/qdrant/qdrant-helm/pull/213
+      description: Update Qdrant to v1.11.1


### PR DESCRIPTION
This updates the Helm chart to [Qdrant 1.11.1](https://github.com/qdrant/qdrant/releases/tag/v1.11.1).

Follows the pattern of <https://github.com/qdrant/qdrant-helm/pull/208>.

Please review with care, as I haven't tested the new Chart.