### PR TITLE
Qdrant 1.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.11.2](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.11.2) (2024-08-28)
+
+- Update Qdrant to v1.11.2
+
 ## [qdrant-1.11.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.11.1) (2024-08-27)
 
 - Update Qdrant to v1.11.1

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [qdrant-1.11.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.11.1) (2024-08-27)
+## [qdrant-1.11.2](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.11.2) (2024-08-28)
 
-- Update Qdrant to v1.11.1
+- Update Qdrant to v1.11.2
 
 For the full changelog, see [CHANGELOG.md](https://github.com/qdrant/qdrant-helm/blob/main/CHANGELOG.md).
 

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,10 +13,10 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 1.11.1
-appVersion: v1.11.1
+version: 1.11.2
+appVersion: v1.11.2
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
     - kind: added
-      description: Update Qdrant to v1.11.1
+      description: Update Qdrant to v1.11.2


### PR DESCRIPTION
Update the Helm chart to [Qdrant 1.11.2](https://github.com/qdrant/qdrant/releases/tag/v1.11.2).