### PR TITLE
feat: allow to disable persistence

### DIFF
--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -239,6 +239,7 @@ spec:
         {{- if .Values.additionalVolumes }}
 {{- toYaml .Values.additionalVolumes | default "" | nindent 8 }}
         {{- end}}
+{{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: {{ .Values.persistence.storageVolumeName | default "qdrant-storage" }}
@@ -276,3 +277,4 @@ spec:
           requests:
             storage: {{ .Values.snapshotPersistence.size | quote }}
     {{- end }}
+{{- end }}

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -138,6 +138,7 @@ affinity: {}
 topologySpreadConstraints: []
 
 persistence:
+  enabled: true
   accessModes: ["ReadWriteOnce"]
   size: 10Gi
   annotations: {}


### PR DESCRIPTION
Reason: if you want to run qdrant on nvme localstorage without persistence for optimal performances/costs