### PR TITLE
Qdrant 1.11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.11.5](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.11.5) (2024-09-23)
+
+- Update Qdrant to v1.11.5
+
 ## [qdrant-1.11.4](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.11.4) (2024-09-18)
 
 - Update Qdrant to v1.11.4

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,10 +1,8 @@
 # Changelog
 
-## [qdrant-1.11.4](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.11.4) (2024-09-18)
+## [qdrant-1.11.5](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.11.5) (2024-09-23)
 
-- Update Qdrant to v1.11.4
-- Prefer read_only_api_key in ServiceMonitor [#221](https://github.com/qdrant/qdrant-helm/pull/221)
-- Added support for reading apiKey and readOnlyApiKey from external secrets [#230](https://github.com/qdrant/qdrant-helm/pull/230)
+- Update Qdrant to v1.11.5
 
 For the full changelog, see [CHANGELOG.md](https://github.com/qdrant/qdrant-helm/blob/main/CHANGELOG.md).
 

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,20 +13,10 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 1.11.4
-appVersion: v1.11.4
+version: 1.11.5
+appVersion: v1.11.5
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
     - kind: added
-      description: Update Qdrant to v1.11.4
-    - kind: added
-      description: Prefer read_only_api_key in ServiceMonitor
-      links:
-        - name: Github Issue
-          url: https://github.com/qdrant/qdrant-helm/pull/221
-    - kind: added
-      description: Added support for reading apiKey and readOnlyApiKey from external secrets
-      links:
-        - name: Github Issue
-          url: https://github.com/qdrant/qdrant-helm/pull/230
+      description: Update Qdrant to v1.11.5


### PR DESCRIPTION
Update the Helm chart to [Qdrant 1.11.5](https://github.com/qdrant/qdrant/releases/tag/v1.11.5).

I do not see any other changes on the main branch, so I limited the change log(s) to just the version bump again. Follows the pattern of <https://github.com/qdrant/qdrant-helm/pull/242>.