### PR TITLE
unify helm chart repo name to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ This repository hosts the following helm charts:
 ## Usage
 
 ```bash
-helm repo add qdrant https://qdrant.github.io/qdrant-helm
+helm repo add qdrant_helm https://qdrant.github.io/qdrant-helm
 helm repo update
-helm upgrade -i your-qdrant-installation-name qdrant/qdrant
+helm upgrade -i your-qdrant-installation-name qdrant_helm/qdrant
 ```
 
 For more in-depth usage documentation, see [the helm chart's README](charts/qdrant/README.md).
@@ -22,7 +22,7 @@ This helm chart installs the latest version of Qdrant by default. When a new ver
 
 ```bash
 helm repo update
-helm upgrade your-qdrant-installation-name qdrant/qdrant
+helm upgrade your-qdrant-installation-name qdrant_helm/qdrant
 ```
 
 This command performs a rolling upgrade of your Qdrant cluster, updating one node at a time.

--- a/charts/qdrant/README.md
+++ b/charts/qdrant/README.md
@@ -5,9 +5,9 @@
 ## TLDR
 
 ```bash
-helm repo add qdrant https://qdrant.github.io/qdrant-helm
+helm repo add qdrant_helm https://qdrant.github.io/qdrant-helm
 helm repo update
-helm upgrade -i your-qdrant-installation-name qdrant/qdrant
+helm upgrade -i your-qdrant-installation-name qdrant_helm/qdrant
 ```
 
 ## Description
@@ -25,7 +25,7 @@ This chart installs and bootstraps a Qdrant instance.
 You can install the chart from source via:
 
 ```bash
-helm upgrade -i your-qdrant-installation-name charts/qdrant
+helm upgrade -i your-qdrant-installation-name qdrant_helm/qdrant
 ```
 
 Uninstall via:


### PR DESCRIPTION
The main README.md and /charts/qdrant/README.md (even the TLDR and the main text there) use different names for the helm chart repo, so this caused some of the commands to fail.

Unified this to qdrant_helm, so all instructions are consistent.