### PR TITLE
Update chart to Qdrant 1.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [qdrant-1.12.4](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.4) (2024-11-12)
+## [qdrant-1.12.4](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.4) (2024-11-18)
 
-- Update Qdrant to v1.12.3
+- Update Qdrant to v1.12.4
 
 ## [qdrant-1.12.3](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.3) (2024-11-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.12.4](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.4) (2024-11-12)
+
+- Update Qdrant to v1.12.3
+
 ## [qdrant-1.12.3](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.3) (2024-11-11)
 
 - Update Qdrant to v1.12.2

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [qdrant-1.12.4](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.4) (2024-11-12)
+## [qdrant-1.12.4](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.4) (2024-11-18)
 
-- Update Qdrant to v1.12.3
+- Update Qdrant to v1.12.4
 
 ## [qdrant-1.12.3](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.3) (2024-11-11)
 

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.12.4](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.4) (2024-11-12)
+
+- Update Qdrant to v1.12.3
+
 ## [qdrant-1.12.3](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.3) (2024-11-11)
 
 - Update Qdrant to v1.12.2

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,10 +13,10 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 1.12.3
-appVersion: v1.12.2
+version: 1.12.4
+appVersion: v1.12.3
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
     - kind: added
-      description: Update Qdrant to v1.12.2
+      description: Update Qdrant to v1.12.3

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -14,9 +14,9 @@ maintainers:
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
 version: 1.12.4
-appVersion: v1.12.3
+appVersion: v1.12.4
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
     - kind: added
-      description: Update Qdrant to v1.12.3
+      description: Update Qdrant to v1.12.4

--- a/test/integration/default_installation.bats
+++ b/test/integration/default_installation.bats
@@ -12,7 +12,7 @@ setup_file() {
     run kubectl logs -n qdrant-helm-integration qdrant-0
     [ $status -eq 0 ]
     [[ "${output}" =~ .*INFO.* ]]
-    if [[ ! "${output}" =~ .*WARN.* ]]; then
+    if [[ "${output}" =~ .*WARN.* ]]; then
         echo "Found warning output:"
         echo "${output}"
         return 1

--- a/test/integration/default_installation.bats
+++ b/test/integration/default_installation.bats
@@ -9,7 +9,6 @@ setup_file() {
 }
 
 @test "no startup warnings in logs" {
-    skip "Skip for 1.12.2 which has a known warning"
     run kubectl logs -n qdrant-helm-integration qdrant-0
     [ $status -eq 0 ]
     [[ "${output}" =~ .*INFO.* ]]


### PR DESCRIPTION
Update for [Qdrant 1.12.3](https://github.com/qdrant/qdrant/releases/tag/v1.12.3).

Follows the pattern of <https://github.com/qdrant/qdrant-helm/pull/262>.