### PR TITLE
Update chart to Qdrant 1.12.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.12.6](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.6) (2025-01-08)
+
+- Update Qdrant to v1.12.6
+
 ## [qdrant-1.12.5](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.5) (2024-12-09)
 
 - Update Qdrant to v1.12.5

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.12.6](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.6) (2025-01-08)
+
+- Update Qdrant to v1.12.6
+
 ## [qdrant-1.12.5](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.5) (2024-12-09)
 
 - Update Qdrant to v1.12.5

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,10 +13,10 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 1.12.5
-appVersion: v1.12.5
+version: 1.12.6
+appVersion: v1.12.6
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
     - kind: added
-      description: Update Qdrant to v1.12.5
+      description: Update Qdrant to v1.12.6


### PR DESCRIPTION
Update to Qdrant v1.12.6.

Follows the pattern of <https://github.com/qdrant/qdrant-helm/pull/272>.

I did notice some other changes on the main branch which I left out of the change log. I'm not sure if that's desired.