### PR TITLE
Bump Qdrant to 1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.13.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.0) (2025-01-16)
+
+- Update Qdrant to v1.13.0
+
 ## [qdrant-1.12.6](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.6) (2025-01-08)
 
 - Update Qdrant to v1.12.6

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.13.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.0) (2025-01-16)
+
+- Update Qdrant to v1.13.0
+
 ## [qdrant-1.12.6](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.6) (2025-01-08)
 
 - Update Qdrant to v1.12.6

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,10 +13,10 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 1.12.6
-appVersion: v1.12.6
+version: 1.13.0
+appVersion: v1.13.0
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
     - kind: added
-      description: Update Qdrant to v1.12.6
+      description: Update Qdrant to v1.13.0


### PR DESCRIPTION
Update to Qdrant v1.13.0.

Follows the pattern of <https://github.com/qdrant/qdrant-helm/pull/283>.