### PR TITLE
Bump Qdrant to 1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.13.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.1) (2025-01-23)
+
+- Update Qdrant to v1.13.1
+
 ## [qdrant-1.13.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.0) (2025-01-16)
 
 - Update Qdrant to v1.13.0

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.13.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.1) (2025-01-23)
+
+- Update Qdrant to v1.13.1
+
 ## [qdrant-1.13.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.0) (2025-01-16)
 
 - Update Qdrant to v1.13.0

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,10 +13,10 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 1.13.0
-appVersion: v1.13.0
+version: 1.13.1
+appVersion: v1.13.1
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
     - kind: added
-      description: Update Qdrant to v1.13.0
+      description: Update Qdrant to v1.13.1


### PR DESCRIPTION
Update to Qdrant v1.13.1.

Follows the pattern of <https://github.com/qdrant/qdrant-helm/pull/284>.