### PR TITLE
Bump Qdrant to 1.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.13.4](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.4) (2025-02-17)
+
+- Update Qdrant to v1.13.4
+
 ## [qdrant-1.13.3](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.3) (2025-02-11)
 
 - Update Qdrant to v1.13.3

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.13.4](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.4) (2025-02-17)
+
+- Update Qdrant to v1.13.4
+
 ## [qdrant-1.13.3](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.3) (2025-02-11)
 
 - Update Qdrant to v1.13.3

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,10 +13,10 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 1.13.3
-appVersion: v1.13.3
+version: 1.13.4
+appVersion: v1.13.4
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
     - kind: added
-      description: Update Qdrant to v1.13.3
+      description: Update Qdrant to v1.13.4


### PR DESCRIPTION
_Qdrant release is still pending_

Update to Qdrant v1.13.4.

Follows the pattern of <https://github.com/qdrant/qdrant-helm/pull/299>.