### PR TITLE
fix: pass on `values.yaml`'s `tolerations` and `nodeSelector` to the test hook pod

### DIFF
--- a/charts/qdrant/templates/tests/test-db-interaction.yaml
+++ b/charts/qdrant/templates/tests/test-db-interaction.yaml
@@ -19,6 +19,14 @@ spec:
         {{- if .Values.additionalVolumeMounts }}
 {{- toYaml .Values.additionalVolumeMounts | default "" | nindent 8 }}
         {{- end}}
+  {{- with .Values.nodeSelector }}
+  nodeSelector:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .Values.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
   volumes:
     - name: test-script
       configMap:

--- a/charts/qdrant/templates/tests/test-db-interaction.yaml
+++ b/charts/qdrant/templates/tests/test-db-interaction.yaml
@@ -21,11 +21,11 @@ spec:
         {{- end}}
   {{- with .Values.nodeSelector }}
   nodeSelector:
-    {{- toYaml . | nindent 8 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .Values.tolerations }}
   tolerations:
-    {{- toYaml . | nindent 8 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   volumes:
     - name: test-script


### PR DESCRIPTION
i'm on a cluster where everything is completely isolated and every pod must have its own tolerations to get scheduled, and given the current chart my qdrant deployment's status never changes to "Healthy" since the test pod never gets scheduled and tests don't pass.