### PR TITLE
Bump Qdrant to 1.13.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## [qdrant-1.13.5](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.5) (2025-03-21)
 
 - Update Qdrant to v1.13.5
+- Add support for P2P TLS [#314](https://github.com/qdrant/qdrant-helm/pull/314)
+- Make Service appProtocol configurable [#313](https://github.com/qdrant/qdrant-helm/pull/313)
+- Templating for config values [#308](https://github.com/qdrant/qdrant-helm/pull/308)
+- Templating for topologySpreadConstraints [#309](https://github.com/qdrant/qdrant-helm/pull/309)
+- Use tolerations and nodeSelector in test hook [#307](https://github.com/qdrant/qdrant-helm/pull/307)
+- Set Service annotations on headless Service [#305](https://github.com/qdrant/qdrant-helm/pull/305)
+- Support optional subPath for volumeMounts [#271](https://github.com/qdrant/qdrant-helm/pull/271)
 
 ## [qdrant-1.13.4](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.4) (2025-02-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.13.5](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.5) (2025-03-21)
+
+- Update Qdrant to v1.13.5
+
 ## [qdrant-1.13.4](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.4) (2025-02-17)
 
 - Update Qdrant to v1.13.4

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -3,52 +3,13 @@
 ## [qdrant-1.13.5](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.5) (2025-03-21)
 
 - Update Qdrant to v1.13.5
-
-## [qdrant-1.13.4](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.4) (2025-02-17)
-
-- Update Qdrant to v1.13.4
-
-## [qdrant-1.13.3](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.3) (2025-02-11)
-
-- Update Qdrant to v1.13.3
-
-## [qdrant-1.13.2](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.2) (2025-01-28)
-
-- Update Qdrant to v1.13.2
-
-## [qdrant-1.13.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.1) (2025-01-23)
-
-- Update Qdrant to v1.13.1
-
-## [qdrant-1.13.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.0) (2025-01-16)
-
-- Update Qdrant to v1.13.0
-
-## [qdrant-1.12.6](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.6) (2025-01-08)
-
-- Update Qdrant to v1.12.6
-
-## [qdrant-1.12.5](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.5) (2024-12-09)
-
-- Update Qdrant to v1.12.5
-
-## [qdrant-1.12.4](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.4) (2024-11-18)
-
-- Update Qdrant to v1.12.4
-
-## [qdrant-1.12.3](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.3) (2024-11-11)
-
-- Update Qdrant to v1.12.2
-
-## [qdrant-1.12.2](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.2) (2024-10-28)
-
-- Fix release
-
-## [qdrant-1.12.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.12.1) (2024-10-14)
-
-- Update Qdrant to v1.12.1
-
-For the full changelog, see [CHANGELOG.md](https://github.com/qdrant/qdrant-helm/blob/main/CHANGELOG.md).
+- Add support for P2P TLS [#314](https://github.com/qdrant/qdrant-helm/pull/314)
+- Make Service appProtocol configurable [#313](https://github.com/qdrant/qdrant-helm/pull/313)
+- Templating for config values [#308](https://github.com/qdrant/qdrant-helm/pull/308)
+- Templating for topologySpreadConstraints [#309](https://github.com/qdrant/qdrant-helm/pull/309)
+- Use tolerations and nodeSelector in test hook [#307](https://github.com/qdrant/qdrant-helm/pull/307)
+- Set Service annotations on headless Service [#305](https://github.com/qdrant/qdrant-helm/pull/305)
+- Support optional subPath for volumeMounts [#271](https://github.com/qdrant/qdrant-helm/pull/271)
 
 <!-- The contents of this file are included directly in each GitHub release. -->
 <!-- Only include the most-recent release in this file. -->

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.13.5](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.5) (2025-03-21)
+
+- Update Qdrant to v1.13.5
+
 ## [qdrant-1.13.4](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.4) (2025-02-17)
 
 - Update Qdrant to v1.13.4

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -20,3 +20,38 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Update Qdrant to v1.13.5
+    - kind: added
+      description: Add support for P2P TLS
+      links:
+        - name: Github Issue
+          url: https://github.com/qdrant/qdrant-helm/pull/314
+    - kind: added
+      description: Make Service appProtocol configurable
+      links:
+        - name: Github Issue
+          url: https://github.com/qdrant/qdrant-helm/pull/313    
+    - kind: added
+      description: Templating for config values
+      links:
+        - name: Github Issue
+          url: https://github.com/qdrant/qdrant-helm/pull/308    
+    - kind: added
+      description: Templating for topologySpreadConstraints
+      links:
+        - name: Github Issue
+          url: https://github.com/qdrant/qdrant-helm/pull/309    
+    - kind: added
+      description: Use tolerations and nodeSelector in test hook
+      links:
+        - name: Github Issue
+          url: https://github.com/qdrant/qdrant-helm/pull/307    
+    - kind: added
+      description: Set Service annotations on headless Service
+      links:
+        - name: Github Issue
+          url: https://github.com/qdrant/qdrant-helm/pull/305    
+    - kind: added
+      description: Support optional subPath for volumeMounts
+      links:
+        - name: Github Issue
+          url: https://github.com/qdrant/qdrant-helm/pull/271

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,10 +13,10 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 1.13.4
-appVersion: v1.13.4
+version: 1.13.5
+appVersion: v1.13.5
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
     - kind: added
-      description: Update Qdrant to v1.13.4
+      description: Update Qdrant to v1.13.5


### PR DESCRIPTION
Update to [Qdrant v1.13.5](https://github.com/qdrant/qdrant/releases/tag/v1.13.5).

Follows the pattern of <https://github.com/qdrant/qdrant-helm/pull/302>.