### PR TITLE
Make chart test image configurable

### DIFF
--- a/charts/qdrant/templates/tests/test-db-interaction.yaml
+++ b/charts/qdrant/templates/tests/test-db-interaction.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   containers:
     - name: test-script
-      image: registry.suse.com/bci/bci-base:latest
+      image: {{ .Values.chartTests.dbInteraction.image | quote }}
       args: ['bash', '/app/entrypoint.sh']
       volumeMounts:
         - mountPath: /app

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -262,3 +262,7 @@ additionalVolumes: []
 additionalVolumeMounts: []
 # - name: volumeName
 #   mountPath: "/mount/path"
+
+chartTests:
+  dbInteraction:
+    image: registry.suse.com/bci/bci-base:latest


### PR DESCRIPTION
This change allows users to specify the image name for the chart test
and run tests on airgapped environments.

Signed-off-by: Robert Moucha <robert.moucha@gooddata.com>
