### PR TITLE
fix: do not update fs ownership when useUnprivilegedImage is true

### DIFF
--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -41,7 +41,7 @@ spec:
       shareProcessNamespace: {{ .Values.shareProcessNamespace }}
       {{- end }}
       initContainers:
-      {{- if .Values.updateVolumeFsOwnership }}
+      {{- if and .Values.updateVolumeFsOwnership (not .Values.image.useUnprivilegedImage) }}
       {{- if and .Values.containerSecurityContext .Values.containerSecurityContext.runAsUser }}
       - name: ensure-dir-ownership
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -114,8 +114,8 @@ lifecycle:
       # duration to be greater than the LB's health check interval.
       command: ["sleep", "3"]
 
-# If true ensures that the pre-existing files on the storage and snapshot volume are owned by the container's
-# user and fsGroup
+# Unless .Values.image.useUnprivilegedImage is set to true, ensures that the pre-existing
+# files on the storage and snapshot volume are owned by the container's user and fsGroup.
 updateVolumeFsOwnership: true
 
 nodeSelector: {}


### PR DESCRIPTION
This pull request ensures that we don't attempt to update the volume filesystem ownership when `.Values.image.useUnprivilegedImage` is set to `true`. This will prevent issues like [this one](https://github.com/qdrant/qdrant-helm/issues/82) and make it easier for users.