### PR TITLE
Bump Qdrant to 1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.14.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.14.0) (2025-04-22)
+
+- Update Qdrant to v1.14.0
+
 ## [qdrant-1.13.6](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.6) (2025-04-01)
 
 - Update Qdrant to v1.13.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ## [qdrant-1.13.6](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.6) (2025-04-01)
 
 - Update Qdrant to v1.13.6
+- Make chart test image configurable [#320](https://github.com/qdrant/qdrant-helm/pull/320)
+- Do not unnecessarily update file system ownership when unprivilged image is not used [#321](https://github.com/qdrant/qdrant-helm/pull/321) 
 
 ## [qdrant-1.13.5](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.5) (2025-03-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 ## [qdrant-1.14.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.14.0) (2025-04-22)
 
 - Update Qdrant to v1.14.0
+- Make chart test image configurable [#320](https://github.com/qdrant/qdrant-helm/pull/320)
+- Do not unnecessarily update file system ownership when unprivilged image is not used [#321](https://github.com/qdrant/qdrant-helm/pull/321) 
 
 ## [qdrant-1.13.6](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.6) (2025-04-01)
 
 - Update Qdrant to v1.13.6
-- Make chart test image configurable [#320](https://github.com/qdrant/qdrant-helm/pull/320)
-- Do not unnecessarily update file system ownership when unprivilged image is not used [#321](https://github.com/qdrant/qdrant-helm/pull/321) 
 
 ## [qdrant-1.13.5](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.5) (2025-03-21)
 

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,19 +1,5 @@
 # Changelog
 
-## [qdrant-1.13.6](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.6) (2025-04-01)
+## [qdrant-1.14.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.14.0) (2025-04-22)
 
-- Update Qdrant to v1.13.6
-
-## [qdrant-1.13.5](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.13.5) (2025-03-21)
-
-- Update Qdrant to v1.13.5
-- Add support for P2P TLS [#314](https://github.com/qdrant/qdrant-helm/pull/314)
-- Make Service appProtocol configurable [#313](https://github.com/qdrant/qdrant-helm/pull/313)
-- Templating for config values [#308](https://github.com/qdrant/qdrant-helm/pull/308)
-- Templating for topologySpreadConstraints [#309](https://github.com/qdrant/qdrant-helm/pull/309)
-- Use tolerations and nodeSelector in test hook [#307](https://github.com/qdrant/qdrant-helm/pull/307)
-- Set Service annotations on headless Service [#305](https://github.com/qdrant/qdrant-helm/pull/305)
-- Support optional subPath for volumeMounts [#271](https://github.com/qdrant/qdrant-helm/pull/271)
-
-<!-- The contents of this file are included directly in each GitHub release. -->
-<!-- Only include the most-recent release in this file. -->
+- Update Qdrant to v1.14.0

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -3,3 +3,5 @@
 ## [qdrant-1.14.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.14.0) (2025-04-22)
 
 - Update Qdrant to v1.14.0
+- Make chart test image configurable [#320](https://github.com/qdrant/qdrant-helm/pull/320)
+- Do not unnecessarily update file system ownership when unprivilged image is not used [#321](https://github.com/qdrant/qdrant-helm/pull/321) 

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -20,3 +20,13 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Update Qdrant to v1.14.0
+    - kind: added
+      description: Make chart test image configurable     
+      links:
+        - name: Github Issue
+          url: https://github.com/qdrant/qdrant-helm/pull/320
+    - kind: fixed
+      description: Do not unnecessarily update file system ownership when unprivilged image is not used 
+      links:
+        - name: Github Issue
+          url: https://github.com/qdrant/qdrant-helm/pull/321

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,10 +13,10 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 1.13.6
-appVersion: v1.13.6
+version: 1.14.0
+appVersion: v1.14.0
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
     - kind: added
-      description: Update Qdrant to v1.13.6
+      description: Update Qdrant to v1.14.0


### PR DESCRIPTION
Update to [Qdrant 1.14.0](https://github.com/qdrant/qdrant/releases/tag/v1.14.0).

Follows the pattern of <https://github.com/qdrant/qdrant-helm/pull/284>.

Please carefully check which files should fully replace and which should append contents. Since we weren't consistent with this previously, I'm not quite sure what the 'right' way is.