### PR TITLE
Bump Qdrant to 1.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [qdrant-1.14.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.14.1) (2025-05-23)
 
 - Update Qdrant to v1.14.1
+- Fix typo in README [#323](https://github.com/qdrant/qdrant-helm/pull/323)
 
 ## [qdrant-1.14.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.14.0) (2025-04-22)
 

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## [qdrant-1.14.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.14.1) (2025-05-23)
 
 - Update Qdrant to v1.14.1
+- Fix typo in README [#323](https://github.com/qdrant/qdrant-helm/pull/323)

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -20,3 +20,8 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Update Qdrant to v1.14.1
+    - kind: fixed
+    - description: Fix typo in README
+      links:
+        - name: Github Issue
+          url: https://github.com/qdrant/qdrant-helm/pull/323


### PR DESCRIPTION
Update to [Qdrant 1.14.1](https://github.com/qdrant/qdrant/releases/tag/v1.14.1).

Follows the pattern of <https://github.com/qdrant/qdrant-helm/pull/327>.