### PR TITLE
Revert " Added conditions for securityContexts "

### DIFF
--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -166,11 +166,9 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if .Values.containerSecurityContext.enabled }}
           {{- with .Values.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
-          {{- end }}
           {{- end }}
           {{- with .Values.lifecycle }}
           lifecycle:
@@ -207,11 +205,9 @@ spec:
           {{- if .Values.additionalVolumeMounts }}
 {{- toYaml .Values.additionalVolumeMounts | default "" | nindent 10 }}
           {{- end}}
-      {{- if .Values.podSecurityContext.enabled }}   
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -94,7 +94,6 @@ resources: {}
   #   memory: 128Mi
 
 containerSecurityContext:
-  enabled: true
   runAsNonRoot: true
   runAsUser: 1000
   runAsGroup: 2000
@@ -103,7 +102,6 @@ containerSecurityContext:
   readOnlyRootFilesystem: true
 
 podSecurityContext:
-  enabled: true
   fsGroup: 3000
   fsGroupChangePolicy: Always
 


### PR DESCRIPTION
Reverts qdrant/qdrant-helm#328

This changes breaks existing installations.

The correct way to set this is already there:

```
podSecurityContext: false
containerSecurityContext: false
```