### PR TITLE
Render fsGroup and runAsUser as int64 excplicitely

### DIFF
--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -48,7 +48,7 @@ spec:
         command:
           - chown
           - -R
-          - {{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}
+          - {{ int64 .Values.containerSecurityContext.runAsUser }}:{{ int64 .Values.podSecurityContext.fsGroup }}
           - /qdrant/storage
           - /qdrant/snapshots
           {{- if and .Values.snapshotRestoration.enabled .Values.snapshotRestoration.pvcName }}


### PR DESCRIPTION

I ran into an issue when using large integer UIDs/GIDs, which are common in OpenShift SCCs. Specifically, when setting runAsUser and fsGroup in values.yaml like so:

```
containerSecurityContext:
  runAsUser: 1000640000

podSecurityContext:
  fsGroup: 1000640000
```
The following block in statefulset.yaml renders the chown command using scientific notation, confirmed locally with `helm template qdrant ./charts/qdrant/`:

```
- chown
- -R
- {{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}
```
```
chown -R 1.00064e+09:1.00064e+09 /qdrant/storage ...
```

Which fails at runtime with:

```
invalid user: '1.00064e+09'
```

### Implemented Fix

Explicitely render `runAsUser` and `fsGroup` as `int64`. This is in accordance with [Helm best practices](https://kodekloud.com/blog/helm-best-practices/)

```
      - name: ensure-dir-ownership
        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
        command:
          - chown
          - -R
          - {{ int64 .Values.containerSecurityContext.runAsUser }}:{{ int64 .Values.podSecurityContext.fsGroup }}
 ```  
Running `helm template qdrant ./charts/qdrant/` after the fix shows the correct output

```
chown -R 1000640000:1000640000 /qdrant/storage ...
```