### PR TITLE
Ensure that open file descriptor limit is set correctly on startup

### DIFF
--- a/charts/qdrant/templates/configmap.yaml
+++ b/charts/qdrant/templates/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
 data:
   initialize.sh: |
     #!/bin/sh
+    ulimit -n 65536
     SET_INDEX=${HOSTNAME##*-}
     {{- if and (.Values.snapshotRestoration.enabled) (eq (.Values.replicaCount | quote)  (1 | quote)) }}
     echo "Starting initializing for pod $SET_INDEX and snapshots restoration"

--- a/charts/qdrant/templates/configmap.yaml
+++ b/charts/qdrant/templates/configmap.yaml
@@ -7,7 +7,11 @@ metadata:
 data:
   initialize.sh: |
     #!/bin/sh
-    ulimit -n 65536
+    echo "Soft limits"
+    ulimit -a -S
+    echo "Hard limits"
+    ulimit -a -H
+    ulimit -n $(ulimit -Hn)
     SET_INDEX=${HOSTNAME##*-}
     {{- if and (.Values.snapshotRestoration.enabled) (eq (.Values.replicaCount | quote)  (1 | quote)) }}
     echo "Starting initializing for pod $SET_INDEX and snapshots restoration"


### PR DESCRIPTION
Follow up on https://github.com/qdrant/qdrant-helm/pull/347

This solves the following issue for Kubernetes deployments through Helm: https://github.com/qdrant/qdrant/issues/4906