### PR TITLE
Add support for additional annotations in Kubernetes resource templates

### DIFF
--- a/charts/qdrant/templates/configmap.yaml
+++ b/charts/qdrant/templates/configmap.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "qdrant.fullname" . }}
   labels:
     {{- include "qdrant.labels" . | nindent 4 }}
+{{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 data:
   initialize.sh: |
     #!/bin/sh

--- a/charts/qdrant/templates/ingress.yaml
+++ b/charts/qdrant/templates/ingress.yaml
@@ -8,10 +8,15 @@ metadata:
     {{- with .Values.ingress.additionalLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.ingress.annotations }}
+{{- if or .Values.ingress.annotations .Values.additionalAnnotations }}
   annotations:
+{{- with .Values.additionalAnnotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+{{- end }}
+{{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end }}
 spec:
   {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}

--- a/charts/qdrant/templates/pdb.yaml
+++ b/charts/qdrant/templates/pdb.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "qdrant.fullname" . }}
   labels:
     {{- include "qdrant.labels" . | nindent 4 }}
+{{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   {{- with  .Values.podDisruptionBudget.maxUnavailable}}
   maxUnavailable: {{ . }}

--- a/charts/qdrant/templates/secret.yaml
+++ b/charts/qdrant/templates/secret.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "qdrant.fullname" . }}-apikey
   labels:
     {{- include "qdrant.labels" . | nindent 4 }}
+{{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 data:
 {{ include "qdrant.secret" . | indent 2}}
 {{- end }}

--- a/charts/qdrant/templates/service-headless.yaml
+++ b/charts/qdrant/templates/service-headless.yaml
@@ -8,9 +8,14 @@ metadata:
 {{- with .Values.service.additionalLabels }}
 {{- toYaml . | nindent 4 }}
 {{- end }}
-{{- if .Values.service.annotations }}
+{{- if or .Values.service.annotations .Values.additionalAnnotations }}
   annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
+{{- with .Values.additionalAnnotations }}
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 {{- end }}
 spec:
   clusterIP: None

--- a/charts/qdrant/templates/service.yaml
+++ b/charts/qdrant/templates/service.yaml
@@ -7,9 +7,14 @@ metadata:
 {{- with .Values.service.additionalLabels }}
 {{- toYaml . | nindent 4 }}
 {{- end }}
-{{- if .Values.service.annotations }}
+{{- if or .Values.service.annotations .Values.additionalAnnotations }}
   annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
+{{- with .Values.additionalAnnotations }}
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 {{- end }}
 spec:
   type: {{ .Values.service.type | default "ClusterIP" }}

--- a/charts/qdrant/templates/serviceaccount.yaml
+++ b/charts/qdrant/templates/serviceaccount.yaml
@@ -2,9 +2,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "qdrant.fullname" . }}
-{{- if .Values.serviceAccount.annotations }}
+{{- if or .Values.serviceAccount.annotations .Values.additionalAnnotations }}
   annotations:
-{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+{{- with .Values.additionalAnnotations }}
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 {{- end }}
   labels:
     {{- include "qdrant.labels" . | nindent 4 }}

--- a/charts/qdrant/templates/servicemonitor.yaml
+++ b/charts/qdrant/templates/servicemonitor.yaml
@@ -8,6 +8,10 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
   name: {{ include "qdrant.fullname" . }}
+{{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   endpoints:
     - honorLabels: true

--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -7,6 +7,10 @@ metadata:
 {{- with .Values.additionalLabels }}
 {{- toYaml . | nindent 4 }}
 {{- end }}
+{{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}

--- a/charts/qdrant/templates/tests/test-db-interaction.yaml
+++ b/charts/qdrant/templates/tests/test-db-interaction.yaml
@@ -8,6 +8,9 @@ metadata:
     {{- include "qdrant.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
+{{- with .Values.additionalAnnotations }}
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   containers:
     - name: test-script
@@ -45,6 +48,9 @@ metadata:
     {{- include "qdrant.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
+{{- with .Values.additionalAnnotations }}
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 data:
   entrypoint.sh: |
     #!/bin/bash

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -82,6 +82,8 @@ startupProbe:
   successThreshold: 1
 
 additionalLabels: {}
+# additionalAnnotations will be added to all top-level resources (StatefulSet, Service, ConfigMap, etc.)
+additionalAnnotations: {}
 podAnnotations: {}
 podLabels: {}
 


### PR DESCRIPTION
## Summary

Added a new `additionalAnnotations` configuration property that allows users to add custom annotations to all top-level Kubernetes resources created by the Qdrant Helm chart.

## Changes Made

### New Configuration Property

- Added `additionalAnnotations: {}` to `values.yaml` with documentation explaining its purpose

### Template Updates

Updated all template files to include the `additionalAnnotations`:

**Simple templates** (added new annotations section):
- `configmap.yaml`
- `pdb.yaml` 
- `secret.yaml`
- `servicemonitor.yaml`
- `statefulset.yaml`
- `tests/test-db-interaction.yaml`

**Templates with existing annotations** (merged with existing annotations):
- `ingress.yaml`
- `service-headless.yaml`
- `service.yaml`
- `serviceaccount.yaml`

## Usage

Users can now add annotations to all top-level resources like this:

```yaml
additionalAnnotations:
  my-company.com/team: "platform"
  my-company.com/environment: "production"
  monitoring.example.com/scrape: "true"
```

## Key Features

- **Scope**: Applies to all top-level resources (StatefulSet, Services, ConfigMaps, Secrets, etc.)
- **Exclusions**: Does NOT apply to pods managed by the StatefulSet (as requested)
- **Merging**: Properly merges with existing resource-specific annotations
- **Conditional**: Only adds annotations section when `additionalAnnotations` is non-empty
- **Consistent**: Follows existing Helm chart patterns and conventions
