### PR TITLE
Bump Qdrant to 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [qdrant-1.15.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.15.0) (2025-07-18)
 
 - Update Qdrant to v1.15.0
+- Use correct value in readOnlyApiKey check [#340](https://github.com/qdrant/qdrant-helm/pull/340)
+- Ensure that open file descriptor limit is set correctly on startup [#355](https://github.com/qdrant/qdrant-helm/pull/355)
+- Fix fsGroup and runAsUser not being int64 type [#354](https://github.com/qdrant/qdrant-helm/pull/354), [#357](https://github.com/qdrant/qdrant-helm/pull/357)
 
 ## [qdrant-1.14.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.14.1) (2025-05-23)
 

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -3,3 +3,6 @@
 ## [qdrant-1.15.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.15.0) (2025-07-18)
 
 - Update Qdrant to v1.15.0
+- Use correct value in readOnlyApiKey check [#340](https://github.com/qdrant/qdrant-helm/pull/340)
+- Ensure that open file descriptor limit is set correctly on startup [#355](https://github.com/qdrant/qdrant-helm/pull/355)
+- Fix fsGroup and runAsUser not being int64 type [#354](https://github.com/qdrant/qdrant-helm/pull/354), [#357](https://github.com/qdrant/qdrant-helm/pull/357)

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -20,3 +20,20 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Update Qdrant to v1.15.0
+    - kind: fixed
+      description: Use correct value in readOnlyApiKey check
+      links:
+        - name: Github Issue
+          url: https://github.com/qdrant/qdrant-helm/pull/340
+    - kind: fixed
+      description: Ensure that open file descriptor limit is set correctly on startup
+      links:
+        - name: Github Issue
+          url: https://github.com/qdrant/qdrant-helm/pull/355
+    - kind: fixed
+      description: Fix fsGroup and runAsUser not being int64 type
+      links:
+        - name: Github Issue
+          url: https://github.com/qdrant/qdrant-helm/pull/354
+        - name: Github Issue
+          url: https://github.com/qdrant/qdrant-helm/pull/357


### PR DESCRIPTION
Update to [Qdrant 1.15.0](https://github.com/qdrant/qdrant/releases/tag/v1.15.0).

Follows the pattern of <https://github.com/qdrant/qdrant-helm/pull/338>.

I did add change log items for the other PRs I found in the commit change log. Please have a look at them to make sure it is sufficient.

#### Tasks
- [x] Wait for Qdrant 1.15.0 Docker image: https://github.com/qdrant/qdrant/actions/runs/16366722214
- [x] Wait for Qdrant 1.15.0 release to be published: https://github.com/qdrant/qdrant/releases/tag/v1.15.0