### PR TITLE
Bump Qdrant to 1.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.15.2](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.15.2) (2025-08-12)
+
+- Update Qdrant to v1.15.2
+
 ## [qdrant-1.15.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.15.1) (2025-07-24)
 
 - Update Qdrant to v1.15.1

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
-## [qdrant-1.15.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.15.1) (2025-07-24)
+## [qdrant-1.15.2](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.15.2) (2025-08-12)
 
-- Update Qdrant to v1.15.1
-- Add support for additional annotations in Kubernetes resource templates [#359](https://github.com/qdrant/qdrant-helm/pull/359)
+- Update Qdrant to v1.15.2
 

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,15 +13,10 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 1.15.1
-appVersion: v1.15.1
+version: 1.15.2
+appVersion: v1.15.2
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
     - kind: added
-      description: Update Qdrant to v1.15.1
-    - kind: added
-      description: Add support for additional annotations in Kubernetes resource templates
-      links:
-        - name: Github Issue
-          url: https://github.com/qdrant/qdrant-helm/pull/359
+      description: Update Qdrant to v1.15.2


### PR DESCRIPTION
Update to [Qdrant 1.15.2](https://github.com/qdrant/qdrant/releases/tag/v1.15.2).

Follows the pattern of <https://github.com/qdrant/qdrant-helm/pull/361>.