### PR TITLE
Bump Qdrant to 1.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.15.3](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.15.3) (2025-08-14)
+
+- Update Qdrant to v1.15.3
+
 ## [qdrant-1.15.2](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.15.2) (2025-08-12)
 
 - Update Qdrant to v1.15.2

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [qdrant-1.15.2](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.15.2) (2025-08-12)
+## [qdrant-1.15.3](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.15.3) (2025-08-14)
 
-- Update Qdrant to v1.15.2
+- Update Qdrant to v1.15.3
 

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,10 +13,10 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 1.15.2
-appVersion: v1.15.2
+version: 1.15.3
+appVersion: v1.15.3
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
     - kind: added
-      description: Update Qdrant to v1.15.2
+      description: Update Qdrant to v1.15.3


### PR DESCRIPTION
Update to [Qdrant 1.15.3](https://github.com/qdrant/qdrant/releases/tag/v1.15.3).

Follows the pattern of <https://github.com/qdrant/qdrant-helm/pull/367>.