### PR TITLE
Fix cannot overwrite table

### DIFF
--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -10,7 +10,7 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 args: ["./config/initialize.sh"]
-env: {}
+env: []
   # - name: QDRANT_ALLOW_RECOVERY_MODE
   #   value: true
 


### PR DESCRIPTION
When using the `env` in values, like this:

```yaml
  env:
    - name: QDRANT__LOG_LEVEL
      value: WARNING
```

And executing `helm template` for example, the following warning appear 

```bash
coalesce.go:298: warning: cannot overwrite table with non table for Qdrant.qdrant.database.env (map[])
```