### PR TITLE
feat(helm): publish Helm chart to Github OCI registry

### DIFF
--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -48,3 +48,19 @@ jobs:
         with:
           commit_message: "Update index.html"
 
+      - name: Login to GHCR
+        uses: docker/login-action@v3.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push chart to GHCR
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*.tgz; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/qdrant-helm"
+          done


### PR DESCRIPTION
With Helm v3.8.0, the OCI support became [GA](https://helm.sh/docs/topics/registries), which is an excellent chance to start publishing Helm charts to OCI-compliant registries.
