### PR TITLE
Bump Qdrant to 1.15.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.15.5](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.15.5) (2025-09-30)
+
+- Update Qdrant to v1.15.5
+
 ## [qdrant-1.15.4](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.15.4) (2025-08-27)
 
 - Update Qdrant to v1.15.4

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [qdrant-1.15.4](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.15.4) (2025-08-27)
+## [qdrant-1.15.5](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.15.4) (2025-09-30)
 
-- Update Qdrant to v1.15.4
+- Update Qdrant to v1.15.5
 

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,10 +13,10 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 1.15.4
-appVersion: v1.15.4
+version: 1.15.5
+appVersion: v1.15.5
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
     - kind: added
-      description: Update Qdrant to v1.15.4
+      description: Update Qdrant to v1.15.5


### PR DESCRIPTION
Update to [Qdrant 1.15.5](https://github.com/qdrant/qdrant/releases/tag/v1.15.5).

Follows the pattern of <https://github.com/qdrant/qdrant-helm/pull/378>.