### PR TITLE
fix(chart): add service.enable_tls to values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.15.6](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.15.6) (2025-09-30)
+
+- Add service.enable_tls to values to fix test-db-interaction test.
+
 ## [qdrant-1.15.5](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.15.5) (2025-09-30)
 
 - Update Qdrant to v1.15.5

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.15.6](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.15.6) (2025-09-30)
+
+- Add service.enable_tls to values to fix test-db-interaction test.
+
 ## [qdrant-1.15.5](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.15.4) (2025-09-30)
 
 - Update Qdrant to v1.15.5

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,10 +13,10 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 1.15.5
+version: 1.15.6
 appVersion: v1.15.5
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
-    - kind: added
-      description: Update Qdrant to v1.15.5
+    - kind: fixed
+      description: Add service.enable_tls to values to fix test-db-interaction test.

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -181,6 +181,8 @@ config:
       enable_tls: false
     consensus:
       tick_period_ms: 100
+  service:
+    enable_tls: false
 
 sidecarContainers: []
 # sidecarContainers:


### PR DESCRIPTION
The test-db-interaction test was failing because it was checking for `config.service.enable_tls` which did not exist in the `values.yaml` file.

This commit adds the `service.enable_tls` key to the `config` section of the `values.yaml` file and sets its default value to `false`. This allows the test to correctly determine whether to use http or https when connecting to the qdrant service.