### PR TITLE
Bump Qdrant to 1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [qdrant-1.16.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.16.0) (2025-11-17)
 
 - Update Qdrant to v1.16.0
+- Add support for `volumeAttributesClass` for PVCs [#396](https://github.com/qdrant/qdrant-helm/pull/396)
+- Fix helm warning because of wrong data type in env default value [#398](https://github.com/qdrant/qdrant-helm/pull/398)
 
 ## [qdrant-1.15.5](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.15.5) (2025-09-30)
 

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -3,4 +3,6 @@
 ## [qdrant-1.16.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.16.0) (2025-11-17)
 
 - Update Qdrant to v1.16.0
+- Add support for `volumeAttributesClass` for PVCs [#396](https://github.com/qdrant/qdrant-helm/pull/396)
+- Fix Helm warning because of wrong data type in env default value [#398](https://github.com/qdrant/qdrant-helm/pull/398)
 

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -20,3 +20,13 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Update Qdrant to v1.16.0
+    - kind: added
+      description: Add support for `volumeAttributesClass` for PVCs
+      links:
+        - name: GitHub Pull Request
+          url: https://github.com/qdrant/qdrant-helm/pull/396
+    - kind: fixed
+      description: Fix Helm warning because of wrong data type in env default value
+      links:
+        - name: GitHub Pull Request
+          url: https://github.com/qdrant/qdrant-helm/pull/398


### PR DESCRIPTION
Update to [Qdrant 1.16.0](https://github.com/qdrant/qdrant/releases/tag/v1.16.0).

Follows the pattern of <https://github.com/qdrant/qdrant-helm/pull/390>.