### PR TITLE
Add custom authorization support for ServiceMonitor

### DIFF
--- a/charts/qdrant/templates/servicemonitor.yaml
+++ b/charts/qdrant/templates/servicemonitor.yaml
@@ -28,7 +28,10 @@ spec:
       relabelings:
 {{ tpl (toYaml .Values.metrics.serviceMonitor.relabelings | indent 8) . }}
 {{- end }}
-{{- if .Values.readOnlyApiKey }}
+{{- if .Values.metrics.serviceMonitor.authorization }}
+      authorization:
+{{ tpl (toYaml .Values.metrics.serviceMonitor.authorization | indent 8) . }}
+{{- else if .Values.readOnlyApiKey }}
       authorization:
         type: Bearer
         credentials:

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -217,6 +217,15 @@ metrics:
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
     ##
     relabelings: []
+    ## Authorization to apply to the metrics endpoint for the cases when the API key(s) are configured externally
+    ## ref: https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.SafeAuthorization
+    ##
+    authorization: {}
+    # authorization:
+    #   type: Bearer
+    #   credentials:
+    #     name: external-secret-with-api-key
+    #     key: api-key
 
 serviceAccount:
   annotations: {}


### PR DESCRIPTION
Add support for custom authorization configuration in ServiceMonitor to allow users to configure authorization when API keys are configured externally. The authorization field in metrics.serviceMonitor takes precedence over automatic API key detection from apiKey and readOnlyApiKey.

This change adds:
- authorization field to metrics.serviceMonitor in values.yaml
- Support for custom authorization in servicemonitor.yaml template
- Documentation and example in values.yaml