### PR TITLE
Bump Qdrant to 1.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.16.2](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.16.2) (2025-12-03)
+
+- Update Qdrant to v1.16.2
+
 ## [qdrant-1.16.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.16.1) (2025-11-26)
 
 - Update Qdrant to v1.16.1

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
-## [qdrant-1.16.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.16.1) (2025-11-26)
+## [qdrant-1.16.2](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.16.2) (2025-12-03)
 
-- Update Qdrant to v1.16.1
-- Add custom authorization support for ServiceMonitor [#407](https://github.com/qdrant/qdrant-helm/pull/407)
+- Update Qdrant to v1.16.2
 

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,15 +13,10 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 1.16.1
-appVersion: v1.16.1
+version: 1.16.2
+appVersion: v1.16.2
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
     - kind: added
-      description: Update Qdrant to v1.16.1
-    - kind: added
-      description: Add custom authorization support for ServiceMonitor
-      links:
-        - name: GitHub Pull Request
-          url: https://github.com/qdrant/qdrant-helm/pull/407
+      description: Update Qdrant to v1.16.2


### PR DESCRIPTION
Update to [Qdrant 1.16.2](https://github.com/qdrant/qdrant/releases/tag/v1.16.2).

Follows the pattern of <https://github.com/qdrant/qdrant-helm/pull/414>.

### Tasks
- [x] Merge <https://github.com/qdrant/qdrant/pull/7680>
- [x] Push release tag in `qdrant/qdrant`, and wait for Docker images
- [x] Re-run CI in this PR