### PR TITLE
fix: Add the ability to set minReadySeconds

### DIFF
--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -14,6 +14,13 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}
+  {{- if .Values.minReadySeconds }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
+  {{- end }}
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      partition: 0
   selector:
     matchLabels:
       {{- include "qdrant.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
This is an extra layer of safety, which generally should not be necessary if pod disruption budget and startup/readiness probes are set - but for a production upgrade it is a good peace of mind.