### PR TITLE
feat: Add support for setting persistent volume claim labels

### DIFF
--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -260,6 +260,9 @@ spec:
         name: {{ .Values.persistence.storageVolumeName | default "qdrant-storage" }}
         labels:
           app: {{ template "qdrant.name" . }}
+          {{- with .Values.persistence.labels }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         {{- with .Values.persistence.annotations }}
         annotations:
         {{- toYaml . | nindent 10 }}
@@ -281,6 +284,9 @@ spec:
         name: {{ .Values.snapshotPersistence.snapshotsVolumeName | default "qdrant-snapshots" }}
         labels:
           app: {{ template "qdrant.name" . }}
+          {{- with .Values.snapshotPersistence.labels }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         {{- with .Values.snapshotPersistence.annotations }}
         annotations:
         {{- toYaml . | nindent 10 }}

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -145,6 +145,7 @@ persistence:
   accessModes: ["ReadWriteOnce"]
   size: 10Gi
   annotations: {}
+  labels: {}
   # storageVolumeName: qdrant-storage
   # storageSubPath: ""
   # storageClassName: local-path
@@ -158,6 +159,7 @@ snapshotPersistence:
   accessModes: ["ReadWriteOnce"]
   size: 10Gi
   annotations: {}
+  labels: {}
   # snapshotsVolumeName: qdrant-snapshots
   # snapshotsSubPath: ""
   # You can change the storageClassName to ensure snapshots are saved to cold storage.


### PR DESCRIPTION
We use a storage operator that we enable for persistent volume claims by setting a label. Support for setting PVC labels is very useful for us.