### PR TITLE
feat(headless-service): add headlessService config with enabled flag and annotation/label overrides

### DIFF
--- a/charts/qdrant/templates/service-headless.yaml
+++ b/charts/qdrant/templates/service-headless.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.headlessService.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,15 +7,23 @@ metadata:
     {{- include "qdrant.labels" . | nindent 4 }}
     {{- include "qdrant.additionalLabels" . | nindent 4 }}
     app.kubernetes.io/component: cluster-discovery
-{{- with .Values.service.additionalLabels }}
+{{- $additionalLabels := .Values.service.additionalLabels }}
+{{- if not (kindIs "invalid" .Values.headlessService.additionalLabels) }}
+  {{- $additionalLabels = .Values.headlessService.additionalLabels }}
+{{- end }}
+{{- with $additionalLabels }}
 {{- toYaml . | nindent 4 }}
 {{- end }}
-{{- if or .Values.service.annotations .Values.additionalAnnotations }}
+{{- $annotations := .Values.service.annotations }}
+{{- if not (kindIs "invalid" .Values.headlessService.annotations) }}
+  {{- $annotations = .Values.headlessService.annotations }}
+{{- end }}
+{{- if or $annotations .Values.additionalAnnotations }}
   annotations:
 {{- with .Values.additionalAnnotations }}
     {{- toYaml . | nindent 4 }}
 {{- end }}
-{{- with .Values.service.annotations }}
+{{- with $annotations }}
     {{- toYaml . | nindent 4 }}
 {{- end }}
 {{- end }}
@@ -33,3 +42,4 @@ spec:
     {{- end }}
   selector:
     {{- include "qdrant.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -40,6 +40,20 @@ service:
       protocol: TCP
       checksEnabled: false
 
+headlessService:
+  # Set to false to disable the headless service entirely.
+  # Useful when cluster mode is disabled (config.cluster.enabled: false).
+  enabled: true
+  # Overrides service.annotations for the headless service.
+  # null (default): inherits service.annotations (backwards-compatible behaviour).
+  # {}: no annotations on the headless service.
+  # {key: val}: only these annotations.
+  annotations: null
+  # Overrides service.additionalLabels for the headless service.
+  # null (default): inherits service.additionalLabels.
+  # {}: no additional labels on the headless service.
+  additionalLabels: null
+
 ingress:
   enabled: false
   ingressClassName: ""


### PR DESCRIPTION
Closes #445

## Changes

Added `headlessService` section to `values.yaml`:

- `headlessService.enabled` — set to `false` to skip creating the headless service entirely (useful when `config.cluster.enabled: false`)
- `headlessService.annotations` — overrides annotations on the headless service; `null` (default) inherits `service.annotations` for backwards compatibility; `{}` suppresses all annotations
- `headlessService.additionalLabels` — same override semantics for additional labels

## Backwards compatibility

No breaking changes. `null` defaults preserve existing behaviour.