### PR TITLE
Allow config of pod's `terminationGracePeriodSeconds`

### DIFF
--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -50,6 +50,9 @@ spec:
       {{- if .Values.shareProcessNamespace }}
       shareProcessNamespace: {{ .Values.shareProcessNamespace }}
       {{- end }}
+      {{- if hasKey .Values "terminationGracePeriodSeconds" }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       initContainers:
       {{- if and .Values.updateVolumeFsOwnership (not .Values.image.useUnprivilegedImage) }}
       {{- if and .Values.containerSecurityContext .Values.containerSecurityContext.runAsUser }}

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -238,6 +238,8 @@ priorityClassName: ""
 
 shareProcessNamespace: false
 
+# terminationGracePeriodSeconds: 30
+
 # We discourage changing this setting. Using the "OrderedReady" policy in a
 # multi-node cluster will cause a deadlock where nodes refuse to become
 # "Ready" until all nodes are running.


### PR DESCRIPTION
It can be necessary to define `terminationGracePeriodSeconds` for the pods of the statefulset. 

`hasKey` is used to check whether the value is defined so that the `0` value can also be templated properly. `if` would interpret the `0` value as undefined.