### PR TITLE
feat: ability to customize SA name, creation and automount token

### DIFF
--- a/charts/qdrant/templates/_helpers.tpl
+++ b/charts/qdrant/templates/_helpers.tpl
@@ -24,6 +24,17 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Create the name of the service account to use
+*/}}
+{{- define "qdrant.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "qdrant.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "qdrant.chart" -}}

--- a/charts/qdrant/templates/_helpers.tpl
+++ b/charts/qdrant/templates/_helpers.tpl
@@ -24,17 +24,6 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
-Create the name of the service account to use
-*/}}
-{{- define "qdrant.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "qdrant.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
-{{- end }}
-
-{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "qdrant.chart" -}}

--- a/charts/qdrant/templates/serviceaccount.yaml
+++ b/charts/qdrant/templates/serviceaccount.yaml
@@ -15,7 +15,4 @@ metadata:
   labels:
     {{- include "qdrant.labels" . | nindent 4 }}
     {{- include "qdrant.additionalLabels" . | nindent 4 }}
-{{- with .Values.automountServiceAccountToken }}
-automountServiceAccountToken: {{ . }}
-{{- end }}
 {{- end }}

--- a/charts/qdrant/templates/serviceaccount.yaml
+++ b/charts/qdrant/templates/serviceaccount.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "qdrant.fullname" . }}
+  name: {{ include "qdrant.serviceAccountName" . }}
 {{- if or .Values.serviceAccount.annotations .Values.additionalAnnotations }}
   annotations:
 {{- with .Values.additionalAnnotations }}
@@ -14,3 +15,7 @@ metadata:
   labels:
     {{- include "qdrant.labels" . | nindent 4 }}
     {{- include "qdrant.additionalLabels" . | nindent 4 }}
+{{- with .Values.automountServiceAccountToken }}
+automountServiceAccountToken: {{ . }}
+{{- end }}
+{{- end }}

--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -239,9 +239,7 @@ spec:
         {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "qdrant.serviceAccountName" . }}
-      {{- with .Values.automountServiceAccountToken }}
-      automountServiceAccountToken: {{ . }}
-      {{- end }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       volumes:
         - name: qdrant-config
           configMap:

--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -239,6 +239,9 @@ spec:
         {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "qdrant.serviceAccountName" . }}
+      {{- with .Values.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ . }}
+      {{- end }}
       volumes:
         - name: qdrant-config
           configMap:

--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -238,7 +238,7 @@ spec:
       topologySpreadConstraints:
         {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "qdrant.fullname" . }}
+      serviceAccountName: {{ include "qdrant.serviceAccountName" . }}
       volumes:
         - name: qdrant-config
           configMap:

--- a/charts/qdrant/templates/tests/test-db-interaction.yaml
+++ b/charts/qdrant/templates/tests/test-db-interaction.yaml
@@ -45,7 +45,7 @@ spec:
 {{- toYaml .Values.additionalVolumes | default "" | nindent 4 }}
     {{- end}}
   restartPolicy: Never
-  serviceAccountName: {{ include "qdrant.fullname" . }}
+  serviceAccountName: {{ include "qdrant.serviceAccountName" . }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -232,7 +232,10 @@ metrics:
     #     key: api-key
 
 serviceAccount:
+  create: true
+  name: ""
   annotations: {}
+automountServiceAccountToken: true
 
 priorityClassName: ""
 


### PR DESCRIPTION
Add ServiceAccount configurability to the Helm chart:

- **Custom name**: set the ServiceAccount name instead of defaulting to the release name
- **Creation toggle**: opt out of chart-managed ServiceAccount creation to bring your own
- **Automount toggle**: ability to disable `automountServiceAccountToken`