### PR TITLE
feat(image): support pinning qdrant image by digest

### DIFF
--- a/charts/qdrant/templates/_helpers.tpl
+++ b/charts/qdrant/templates/_helpers.tpl
@@ -63,6 +63,39 @@ Additional (global) labels
 {{- end }}
 
 {{/*
+Container image reference for the qdrant container.
+Prefers `image.digest` (immutable, content-addressed) when set, rendering
+`repository@digest`. Otherwise falls back to `repository:tag` with the optional
+`-unprivileged` suffix. When using `digest`, the digest must already point to
+the desired image variant.
+*/}}
+{{- define "qdrant.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- $suffix := ternary "-unprivileged" "" .Values.image.useUnprivilegedImage -}}
+{{- printf "%s:%s%s" .Values.image.repository $tag $suffix -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Semantic-version portion of the qdrant image tag.
+Strips an optional `@sha256:…` suffix from `image.tag` (e.g. `v1.17.1@sha256:…`,
+which Renovate emits when digest-pinning) and falls back to `Chart.AppVersion`
+when the tag is empty. Used by chart logic that needs a valid semver such as
+the readiness-probe-path selection.
+*/}}
+{{- define "qdrant.image.semver" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- if contains "@" $tag -}}
+{{- (split "@" $tag)._0 -}}
+{{- else -}}
+{{- $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "qdrant.serviceAccountName" -}}

--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -54,7 +54,7 @@ spec:
       {{- if and .Values.updateVolumeFsOwnership (not .Values.image.useUnprivilegedImage) }}
       {{- if and .Values.containerSecurityContext .Values.containerSecurityContext.runAsUser }}
       - name: ensure-dir-ownership
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        image: "{{ include "qdrant.image" . }}"
         command:
           - chown
           - -R
@@ -86,7 +86,7 @@ spec:
         {{- toYaml .Values.sidecarContainers | trim | nindent 8 }}
         {{- end}}
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ .Values.image.useUnprivilegedImage | ternary "-unprivileged" "" }}"
+          image: "{{ include "qdrant.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: QDRANT_INIT_FILE_PATH
@@ -141,7 +141,7 @@ spec:
             {{- end }}
             {{- if eq .name "http"}}
             httpGet:
-              path: "{{- if semverCompare ">=1.7.3" ($.Values.image.tag | default $.Chart.AppVersion) -}}/readyz{{else}}/{{end}}"
+              path: "{{- if semverCompare ">=1.7.3" (include "qdrant.image.semver" $) -}}/readyz{{else}}/{{end}}"
               port: {{ .targetPort }}
               {{- if and $values.config.service $values.config.service.enable_tls }}
               scheme: HTTPS

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -4,6 +4,14 @@ image:
   repository: docker.io/qdrant/qdrant
   pullPolicy: IfNotPresent
   tag: ""
+  # SHA256 digest of the image (e.g. `sha256:abc123…`). When set, the container
+  # is referenced as `repository@digest` instead of `repository:tag`, providing
+  # immutable, content-addressed pulls. The digest takes precedence over the
+  # `-unprivileged` suffix, so it must already point to the desired variant.
+  # `tag` is still used by chart logic that relies on the qdrant version
+  # (e.g. selecting the readiness probe path); set both `tag` and `digest` so
+  # the digest pins the image while the tag drives version-aware rendering.
+  digest: ""
   useUnprivilegedImage: false
 
 imagePullSecrets: []

--- a/test/qdrant_image_digest_test.go
+++ b/test/qdrant_image_digest_test.go
@@ -1,0 +1,106 @@
+package test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+const testDigest = "sha256:94728574965d17c6485dd361aa3c0818b325b9016dac5ea6afec7b4b2700865f"
+
+func TestImageDigestPinning(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs("../charts/qdrant")
+	releaseName := "qdrant"
+	require.NoError(t, err)
+
+	tests := []struct {
+		name              string
+		setValues         map[string]string
+		expectedImage     string
+		readinessEndpoint string
+	}{
+		{
+			name: "digest only renders repository@digest",
+			setValues: map[string]string{
+				"image.repository": "test/repo",
+				"image.digest":     testDigest,
+			},
+			expectedImage:     "test/repo@" + testDigest,
+			readinessEndpoint: "/readyz",
+		},
+		{
+			name: "digest with tag still renders repository@digest",
+			setValues: map[string]string{
+				"image.repository": "test/repo",
+				"image.tag":        "v1.17.1",
+				"image.digest":     testDigest,
+			},
+			expectedImage:     "test/repo@" + testDigest,
+			readinessEndpoint: "/readyz",
+		},
+		{
+			name: "digest takes precedence over useUnprivilegedImage suffix",
+			setValues: map[string]string{
+				"image.repository":           "test/repo",
+				"image.digest":               testDigest,
+				"image.useUnprivilegedImage": "true",
+			},
+			expectedImage:     "test/repo@" + testDigest,
+			readinessEndpoint: "/readyz",
+		},
+		{
+			name: "tag@sha256 notation strips digest from semverCompare",
+			setValues: map[string]string{
+				"image.repository": "test/repo",
+				"image.tag":        "v1.17.1@" + testDigest,
+			},
+			expectedImage:     "test/repo:v1.17.1@" + testDigest,
+			readinessEndpoint: "/readyz",
+		},
+		{
+			name: "tag@sha256 notation respects pre-1.7.3 readiness path",
+			setValues: map[string]string{
+				"image.repository": "test/repo",
+				"image.tag":        "v1.6.0@" + testDigest,
+			},
+			expectedImage:     "test/repo:v1.6.0@" + testDigest,
+			readinessEndpoint: "/",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			namespaceName := "qdrant-" + strings.ToLower(random.UniqueId())
+			logger.Log(t, "Namespace: %s\n", namespaceName)
+
+			options := &helm.Options{
+				SetValues:      test.setValues,
+				KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+			}
+
+			output := helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/statefulset.yaml"})
+
+			var statefulSet appsv1.StatefulSet
+			helm.UnmarshalK8SYaml(t, output, &statefulSet)
+
+			container, _ := lo.Find(statefulSet.Spec.Template.Spec.Containers, func(container corev1.Container) bool {
+				return container.Name == "qdrant"
+			})
+
+			require.Equal(t, test.expectedImage, container.Image)
+			require.Equal(t, test.readinessEndpoint, container.ReadinessProbe.HTTPGet.Path)
+		})
+	}
+}


### PR DESCRIPTION
Closes #388.

## What

Add support for pinning the qdrant container image by SHA256 digest, so that the chart can render `repository@sha256:<digest>` and provide immutable, content-addressed pulls.

## Why

Tag-based image references are mutable: anyone with push access to the registry can replace the image behind a tag without changing the tag itself. Digest pinning is a standard supply-chain mitigation but is currently impossible with this chart because:

1. The chart assembles the image as `"{{ repo }}:{{ tag }}"`, so the only way for a user to pass a digest is to stuff `tag@sha256:...` into `image.tag`.
2. `templates/statefulset.yaml` then passes `image.tag` directly to `semverCompare ">=1.7.3"` to pick the readiness probe path, which fails with `error calling semverCompare: invalid semantic version` once the tag contains `@sha256:`.

This PR makes the chart digest-aware on both fronts.

## Changes

### `values.yaml`

A new optional field:

```yaml
image:
  repository: docker.io/qdrant/qdrant
  tag: ""
  digest: ""              # e.g. sha256:abc123…
  useUnprivilegedImage: false
```

### `templates/_helpers.tpl`

Two new helpers:

- `qdrant.image` — renders `repository@digest` when `image.digest` is set, otherwise `repository:tag[-unprivileged]`. Used for both the main container and the `ensure-dir-ownership` initContainer.
- `qdrant.image.semver` — extracts the semver portion of `image.tag` for `semverCompare`. It strips any `@sha256:…` suffix (the form Renovate emits when it digest-pins a Helm value) and falls back to `Chart.AppVersion` when the tag is empty.

### `templates/statefulset.yaml`

Three call sites updated to use the new helpers:

- Main container `image:` → `{{ include "qdrant.image" . }}`
- `ensure-dir-ownership` initContainer `image:` → `{{ include "qdrant.image" . }}`
- Readiness probe path `semverCompare` → uses `include "qdrant.image.semver" $`

### Behaviour matrix

| `image.tag`           | `image.digest` | `useUnprivilegedImage` | Rendered image                          | `semverCompare` input |
| --------------------- | -------------- | ---------------------- | --------------------------------------- | --------------------- |
| `""` (default)        | `""`           | `false`                | `repo:<Chart.AppVersion>`               | `<Chart.AppVersion>`  |
| `v1.6.0`              | `""`           | `true`                 | `repo:v1.6.0-unprivileged`              | `v1.6.0`              |
| `""`                  | `sha256:abc`   | `false`                | `repo@sha256:abc`                       | `<Chart.AppVersion>`  |
| `v1.17.1`             | `sha256:abc`   | `false`                | `repo@sha256:abc`                       | `v1.17.1`             |
| `v1.17.1@sha256:abc`  | `""`           | `false`                | `repo:v1.17.1@sha256:abc` (valid OCI)   | `v1.17.1`             |

Default behaviour is unchanged — with `digest` empty the chart still renders `repository:tag[-unprivileged]` exactly as before.

When both `digest` and `useUnprivilegedImage` are set, the digest takes precedence; users wanting the unprivileged variant must supply the digest of that variant. This is documented inline in `values.yaml`.

## Tests

`helm lint charts/qdrant` passes.

`go test ./test/` passes the entire existing suite plus a new `TestImageDigestPinning` that covers:

- digest-only renders `repository@digest`
- digest with tag still renders `repository@digest`
- digest takes precedence over `useUnprivilegedImage`
- `tag@sha256:` notation strips the digest from `semverCompare` (>=1.7.3 path)
- `tag@sha256:` notation respects pre-1.7.3 readiness path

```
--- PASS: TestImageDigestPinning (0.40s)
    --- PASS: TestImageDigestPinning/digest_only_renders_repository@digest
    --- PASS: TestImageDigestPinning/digest_with_tag_still_renders_repository@digest
    --- PASS: TestImageDigestPinning/digest_takes_precedence_over_useUnprivilegedImage_suffix
    --- PASS: TestImageDigestPinning/tag@sha256_notation_strips_digest_from_semverCompare
    --- PASS: TestImageDigestPinning/tag@sha256_notation_respects_pre-1.7.3_readiness_path
```

I left `Chart.yaml` / `CHANGELOG.md` untouched since per `CONTRIBUTING.md` those are bumped during release. Happy to add the changelog entry if you'd like it in this PR.