### PR TITLE
Bump Qdrant to 1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [qdrant-1.18.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.18.0) (2026-05-11)
 
 - Update Qdrant to v1.18.0
+- Add support for setting `terminationGracePeriodSeconds` [#449](https://github.com/qdrant/qdrant-helm/pull/449)
 
 ## [qdrant-1.17.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.17.1) (2026-03-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.18.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.18.0) (2026-05-11)
+
+- Update Qdrant to v1.18.0
+
 ## [qdrant-1.17.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.17.1) (2026-03-27)
 
 - Update Qdrant to v1.17.1

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## [qdrant-1.18.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.18.0) (2026-05-11)
 
 - Update Qdrant to v1.18.0
+- Add support for setting `terminationGracePeriodSeconds` [#449](https://github.com/qdrant/qdrant-helm/pull/449)

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## [qdrant-1.17.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.17.1) (2026-03-27)
+## [qdrant-1.18.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.18.0) (2026-05-11)
 
-- Update Qdrant to v1.17.1
+- Update Qdrant to v1.18.0

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,10 +13,10 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 1.17.1
-appVersion: v1.17.1
+version: 1.18.0
+appVersion: v1.18.0
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
     - kind: added
-      description: Update Qdrant to v1.17.1
+      description: Update Qdrant to v1.18.0

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -20,3 +20,8 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Update Qdrant to v1.18.0
+    - kind: added
+      description: Add support for setting terminationGracePeriodSeconds
+      links:
+        - name: GitHub Pull Request
+          url: https://github.com/qdrant/qdrant-helm/pull/449


### PR DESCRIPTION
Update to [Qdrant 1.18.0](https://github.com/qdrant/qdrant/releases/tag/v1.18.0) ([PR](https://github.com/qdrant/qdrant/pull/8959)).

Follows the pattern of <https://github.com/qdrant/qdrant-helm/pull/425>.

### Tasks
- [x] Merge <https://github.com/qdrant/qdrant/pull/8959>
- [x] Push release tag in `qdrant/qdrant`, and wait for Docker images
- [x] Re-run CI in this PR
- [ ] Validate change log