### PR TITLE
Bump Qdrant to 1.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.18.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.18.1) (2026-05-22)
+
+- Update Qdrant to v1.18.1
+
 ## [qdrant-1.18.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.18.0) (2026-05-11)
 
 - Update Qdrant to v1.18.0

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Changelog
 
-## [qdrant-1.18.0](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.18.0) (2026-05-11)
+## [qdrant-1.18.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.18.1) (2026-05-22)
 
-- Update Qdrant to v1.18.0
-- Add support for setting `terminationGracePeriodSeconds` [#449](https://github.com/qdrant/qdrant-helm/pull/449)
+- Update Qdrant to v1.18.1

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,15 +13,10 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 1.18.0
-appVersion: v1.18.0
+version: 1.18.1
+appVersion: v1.18.1
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
     - kind: added
-      description: Update Qdrant to v1.18.0
-    - kind: added
-      description: Add support for setting terminationGracePeriodSeconds
-      links:
-        - name: GitHub Pull Request
-          url: https://github.com/qdrant/qdrant-helm/pull/449
+      description: Update Qdrant to v1.18.1


### PR DESCRIPTION
Update to [Qdrant 1.18.1](https://github.com/qdrant/qdrant/releases/tag/v1.18.1) ([PR](https://github.com/qdrant/qdrant/pull/9134)).

Follows the pattern of <https://github.com/qdrant/qdrant-helm/pull/460>.

### Tasks
- [x] Merge <https://github.com/qdrant/qdrant/pull/9134>
- [x] Push release tag in `qdrant/qdrant`, and wait for Docker images
- [x] Re-run CI in this PR