### PR TITLE
Bump Qdrant to 1.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.18.2](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.18.2) (2026-06-03)
+
+- Update Qdrant to v1.18.2
+
 ## [qdrant-1.18.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.18.1) (2026-05-22)
 
 - Update Qdrant to v1.18.1

--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## [qdrant-1.18.1](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.18.1) (2026-05-22)
+## [qdrant-1.18.2](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.18.2) (2026-06-03)
 
-- Update Qdrant to v1.18.1
+- Update Qdrant to v1.18.2

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,10 +13,10 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 1.18.1
-appVersion: v1.18.1
+version: 1.18.2
+appVersion: v1.18.2
 annotations:
   artifacthub.io/category: database
   artifacthub.io/changes: |
     - kind: added
-      description: Update Qdrant to v1.18.1
+      description: Update Qdrant to v1.18.2


### PR DESCRIPTION
Update to [Qdrant 1.18.2](https://github.com/qdrant/qdrant/releases/tag/v1.18.2) ([PR](https://github.com/qdrant/qdrant/pull/9290)).

Follows the pattern of <https://github.com/qdrant/qdrant-helm/pull/460>.

### Tasks
- [x] Merge <https://github.com/qdrant/qdrant/pull/9290>
- [x] Push release tag in `qdrant/qdrant`, and wait for Docker images
- [x] Re-run CI in this PR