### PR TITLE
fix: add apiVersion + kind to statefulsets volumeClaimTemplates

### DIFF
--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -265,7 +265,9 @@ spec:
 {{- toYaml .Values.additionalVolumes | default "" | nindent 8 }}
         {{- end}}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: {{ .Values.persistence.storageVolumeName | default "qdrant-storage" }}
         labels:
           app: {{ template "qdrant.name" . }}
@@ -289,7 +291,9 @@ spec:
           requests:
             storage: {{ .Values.persistence.size | quote }}
     {{- if .Values.snapshotPersistence.enabled }}
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: {{ .Values.snapshotPersistence.snapshotsVolumeName | default "qdrant-snapshots" }}
         labels:
           app: {{ template "qdrant.name" . }}


### PR DESCRIPTION
fixes #456

Adds `apiVersion` and `kind` to the `volumeClaimTemplates` of the `StatefulSet` to prevent persistent drift detection from ArgoCD.

```yaml
  volumeClaimTemplates:
    - apiVersion: v1
      kind: PersistentVolumeClaim
      metadata:
        # ... existing metadata
```