### PR TITLE
feat: add optional image.digest for content-addressed image pinning

### DIFF
--- a/charts/qdrant/CHANGELOG.md
+++ b/charts/qdrant/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [qdrant-1.18.3](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.18.3) (unreleased)
+
+- Add optional `image.digest` for content-addressed image pinning
+
 ## [qdrant-1.18.2](https://github.com/qdrant/qdrant-helm/tree/qdrant-1.18.2) (2026-06-03)
 
 - Update Qdrant to v1.18.2

--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
     url: https://github.com/qdrant
 icon: https://qdrant.github.io/qdrant-helm/logo_with_text.svg
 type: application
-version: 1.18.2
+version: 1.18.3
 appVersion: v1.18.2
 annotations:
   artifacthub.io/category: database

--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
       {{- if and .Values.updateVolumeFsOwnership (not .Values.image.useUnprivilegedImage) }}
       {{- if and .Values.containerSecurityContext .Values.containerSecurityContext.runAsUser }}
       - name: ensure-dir-ownership
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{- if .Values.image.digest }}@{{ .Values.image.digest }}{{- end }}"
         command:
           - chown
           - -R
@@ -89,7 +89,7 @@ spec:
         {{- toYaml .Values.sidecarContainers | trim | nindent 8 }}
         {{- end}}
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ .Values.image.useUnprivilegedImage | ternary "-unprivileged" "" }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ .Values.image.useUnprivilegedImage | ternary "-unprivileged" "" }}{{- if .Values.image.digest }}@{{ .Values.image.digest }}{{- end }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: QDRANT_INIT_FILE_PATH

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -4,6 +4,11 @@ image:
   repository: docker.io/qdrant/qdrant
   pullPolicy: IfNotPresent
   tag: ""
+  # Optional image digest (e.g. "sha256:..."). When set, it is appended to the
+  # image reference (repo:tag@digest) so the pull is content-addressed while
+  # the tag stays a plain semver for the chart's version checks.
+  # Note: with useUnprivilegedImage, provide the digest of the -unprivileged variant.
+  digest: ""
   useUnprivilegedImage: false
 
 imagePullSecrets: []

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -4,10 +4,6 @@ image:
   repository: docker.io/qdrant/qdrant
   pullPolicy: IfNotPresent
   tag: ""
-  # Optional image digest (e.g. "sha256:..."). When set, it is appended to the
-  # image reference (repo:tag@digest) so the pull is content-addressed while
-  # the tag stays a plain semver for the chart's version checks.
-  # Note: with useUnprivilegedImage, provide the digest of the -unprivileged variant.
   digest: ""
   useUnprivilegedImage: false
 


### PR DESCRIPTION
## Problem

Pinning the qdrant image by digest is currently impossible through values. The natural attempt —

```yaml
image:
  tag: "v1.17.1@sha256:94728574965d17c6485dd361aa3c0818b325b9016dac5ea6afec7b4b2700865f"
```

— fails at template time, because `statefulset.yaml` runs `semverCompare` on `image.tag` to pick the readiness path (`/readyz` vs `/`), and the digest suffix is not a valid semver:

```
Error: template: qdrant/templates/statefulset.yaml:147: ... error calling semverCompare: Invalid Semantic Version
```

Digest pinning is required by supply-chain hardening baselines (tag-only pulls resolve at pull time and are not reproducible), so charts that validate the tag need a separate digest field.

## Change

Add an optional `image.digest` (default `""`, no behavior change when unset). When set, it is appended to the image reference for both the init container and the main container:

```
docker.io/qdrant/qdrant:v1.18.2@sha256:9472…
docker.io/qdrant/qdrant:v1.18.2-unprivileged@sha256:…   # with useUnprivilegedImage
```

`image.tag` stays a plain semver, so the existing `semverCompare` readiness logic is untouched. In a `tag@digest` reference the runtime resolves by digest; the tag remains informational.

Documented caveat in values.yaml: with `useUnprivilegedImage: true` the digest must be the `-unprivileged` variant's digest.

## Testing

- `helm lint` clean
- `make test-unit` (terratest suite) passes
- Render matrix verified: digest unset (byte-identical to current output), digest set, digest + `useUnprivilegedImage`

Chart version bumped to 1.18.3 + CHANGELOG entry — happy to adjust if you version differently.