### PR TITLE
feat: add additionalInitContainers support to Qdrant StatefulSet

### DIFF
--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -84,6 +84,9 @@ spec:
           {{- end }}
       {{- end }}
       {{- end }}
+      {{- if .Values.additionalInitContainers }}
+      {{- toYaml .Values.additionalInitContainers | trim | nindent 8 }}
+      {{- end }}
       containers:
         {{- if .Values.sidecarContainers -}}
         {{- toYaml .Values.sidecarContainers | trim | nindent 8 }}

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -188,6 +188,38 @@ config:
   service:
     enable_tls: false
 
+# additionalInitContainers allows injecting extra init containers into the Qdrant pod.
+# Init containers run to completion sequentially before the main Qdrant container starts,
+# making them the correct place for node-level setup that must be done before Qdrant loads
+# its collections (e.g. raising vm.max_map_count so mmap-heavy workloads do not hit
+# ENOMEM when the number of virtual memory areas exceeds the kernel default of 65530).
+#
+# The chart already provides an 'ensure-dir-ownership' init container; entries defined
+# here are appended after it.
+#
+# Example — raise vm.max_map_count on the host node so Qdrant can mmap many shards:
+#
+#   additionalInitContainers:
+#     - name: set-vm-max-map-count
+#       # busybox is sufficient; any image with sysctl works.
+#       image: busybox
+#       # sysctl writes to the host kernel parameter because the container shares the
+#       # host kernel namespace when privileged: true. The value 262144 is Qdrant's
+#       # documented recommendation for production deployments with many collections.
+#       command: ['sysctl', '-w', 'vm.max_map_count=262144']
+#       securityContext:
+#         privileged: true
+#       resources:
+#         requests:
+#           cpu: 1m
+#           memory: 1Mi
+#
+# When to use this instead of sidecarContainers:
+#   - The action must complete *before* Qdrant starts (strict ordering guarantee).
+#   - The action is a one-shot setup step with no ongoing process needed afterwards.
+#   - You want the pod to fail fast if setup fails (init container failure blocks the pod).
+additionalInitContainers: []
+
 sidecarContainers: []
 # sidecarContainers:
 #   - name: my-sidecar


### PR DESCRIPTION
## Problem

  The chart provides no hook for custom init containers. Operators needing
  one-shot node-level setup before Qdrant starts (e.g. raising
  `vm.max_map_count` to avoid `ENOMEM` on mmap-heavy deployments with many
  collections and shards) are forced to use workarounds:

  - A **privileged sidecar** — no ordering guarantee, must `sleep infinity`
    to stay alive alongside Qdrant.
  - A **separate DaemonSet** — decoupled from the pod lifecycle, requires
    node pool label coordination.

  ## Solution

  Add `additionalInitContainers` to `values.yaml` (default `[]`). Entries
  are appended after the existing `ensure-dir-ownership` init container in
  the StatefulSet template, so they run sequentially before Qdrant starts.

  ## Changes

  - `templates/statefulset.yaml` — render `additionalInitContainers` after
    the `ensure-dir-ownership` block.
  - `values.yaml` — add `additionalInitContainers: []` with a fully
    commented real-world example (`vm.max_map_count`) and guidance on when
    to prefer init containers over `sidecarContainers`.

  ## Example usage

  ```yaml
  additionalInitContainers:
    - name: set-vm-max-map-count
      image: busybox
      command: ['sysctl', '-w', 'vm.max_map_count=262144']
      securityContext:
        privileged: true
      resources:
        requests:
          cpu: 1m
          memory: 1Mi