### PR TITLE
fix(helm): Support exisiting ServiceAccount

### DIFF
--- a/charts/qdrant/templates/serviceaccount.yaml
+++ b/charts/qdrant/templates/serviceaccount.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "qdrant.fullname" . }}
+  name: {{ include "qdrant.serviceAccountName" . }}
 {{- if or .Values.serviceAccount.annotations .Values.additionalAnnotations }}
   annotations:
 {{- with .Values.additionalAnnotations }}
@@ -14,3 +15,4 @@ metadata:
   labels:
     {{- include "qdrant.labels" . | nindent 4 }}
     {{- include "qdrant.additionalLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -238,7 +238,7 @@ spec:
       topologySpreadConstraints:
         {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "qdrant.fullname" . }}
+      serviceAccountName: {{ include "qdrant.serviceAccountName" . }}
       volumes:
         - name: qdrant-config
           configMap:

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -232,6 +232,8 @@ metrics:
     #     key: api-key
 
 serviceAccount:
+  create: true
+  name: ""
   annotations: {}
 
 priorityClassName: ""


### PR DESCRIPTION
## Summary

This PR adds support for using an existing Kubernetes `ServiceAccount` with the Helm chart. 
Fixes: (#459)

### Changes

* Added a conditional guard around `templates/serviceaccount.yaml` so a `ServiceAccount` is only created when `serviceAccount.create` is `true`.
* Updated the `StatefulSet` to use the existing `qdrant.serviceAccountName` helper instead of hardcoding the ServiceAccount name.
* Added `serviceAccount.create` and `serviceAccount.name` to the default `values.yaml` to expose the configuration already supported by the helper.

With these changes, users can set:

```yaml
serviceAccount:
  create: false
  name: existing-service-account
```

to reuse a pre-existing `ServiceAccount`, while preserving the current default behavior (`create: true`) for existing deployments.
