### PR TITLE
fix(helm): add configurable namespace override to chart templates

### DIFF
--- a/charts/qdrant/templates/configmap.yaml
+++ b/charts/qdrant/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "qdrant.fullname" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "qdrant.labels" . | nindent 4 }}
     {{- include "qdrant.additionalLabels" . | nindent 4 }}

--- a/charts/qdrant/templates/ingress.yaml
+++ b/charts/qdrant/templates/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "qdrant.fullname" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "qdrant.labels" . | nindent 4 }}
     {{- include "qdrant.additionalLabels" . | nindent 4 }}

--- a/charts/qdrant/templates/pdb.yaml
+++ b/charts/qdrant/templates/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "qdrant.fullname" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "qdrant.labels" . | nindent 4 }}
     {{- include "qdrant.additionalLabels" . | nindent 4 }}

--- a/charts/qdrant/templates/secret.yaml
+++ b/charts/qdrant/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "qdrant.fullname" . }}-apikey
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "qdrant.labels" . | nindent 4 }}
     {{- include "qdrant.additionalLabels" . | nindent 4 }}

--- a/charts/qdrant/templates/service-headless.yaml
+++ b/charts/qdrant/templates/service-headless.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "qdrant.fullname" . }}-headless
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "qdrant.labels" . | nindent 4 }}
     {{- include "qdrant.additionalLabels" . | nindent 4 }}

--- a/charts/qdrant/templates/service.yaml
+++ b/charts/qdrant/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "qdrant.fullname" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "qdrant.labels" . | nindent 4 }}
     {{- include "qdrant.additionalLabels" . | nindent 4 }}

--- a/charts/qdrant/templates/serviceaccount.yaml
+++ b/charts/qdrant/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "qdrant.fullname" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
 {{- if or .Values.serviceAccount.annotations .Values.additionalAnnotations }}
   annotations:
 {{- with .Values.additionalAnnotations }}

--- a/charts/qdrant/templates/servicemonitor.yaml
+++ b/charts/qdrant/templates/servicemonitor.yaml
@@ -9,6 +9,7 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
   name: {{ include "qdrant.fullname" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
 {{- with .Values.additionalAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "qdrant.fullname" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "qdrant.labels" . | nindent 4 }}
     {{- include "qdrant.additionalLabels" . | nindent 4 }}

--- a/charts/qdrant/templates/tests/test-db-interaction.yaml
+++ b/charts/qdrant/templates/tests/test-db-interaction.yaml
@@ -1,10 +1,10 @@
 {{- $root := . }}
-{{- $namespace := .Release.Namespace }}
+{{- $namespace := .Values.namespace | default .Release.Namespace }}
 apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "qdrant.fullname" . }}-test-db-interaction"
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  namespace: {{ $namespace }}
   labels:
     {{- include "qdrant.labels" . | nindent 4 }}
     {{- include "qdrant.additionalLabels" . | nindent 4 }}
@@ -52,7 +52,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ include "qdrant.fullname" . }}-test-db-interaction"
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  namespace: {{ $namespace }}
   labels:
     {{- include "qdrant.labels" . | nindent 4 }}
     {{- include "qdrant.additionalLabels" . | nindent 4 }}

--- a/charts/qdrant/templates/tests/test-db-interaction.yaml
+++ b/charts/qdrant/templates/tests/test-db-interaction.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "qdrant.fullname" . }}-test-db-interaction"
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "qdrant.labels" . | nindent 4 }}
     {{- include "qdrant.additionalLabels" . | nindent 4 }}
@@ -51,6 +52,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ include "qdrant.fullname" . }}-test-db-interaction"
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "qdrant.labels" . | nindent 4 }}
     {{- include "qdrant.additionalLabels" . | nindent 4 }}

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -7,6 +7,7 @@ image:
   useUnprivilegedImage: false
 
 imagePullSecrets: []
+namespace: ""  
 nameOverride: ""
 fullnameOverride: ""
 args: ["./config/initialize.sh"]


### PR DESCRIPTION
## What

Adds an explicit `metadata.namespace` to all chart templates, defaulting to
`.Release.Namespace`, and exposes a `namespace` value to override it.

Closes #432

## Why

I thought this could be useful since some tools (e.g. GitOps controllers using
`helm template` under the hood) expect resources to declare `namespace`
explicitly rather than relying on the implicit release namespace.

## Change

The fix was quite simple: added `namespace: {{ .Values.namespace | default .Release.Namespace }}`
to `metadata` in each template, and added a `namespace: ""` field in
`values.yaml` to allow overriding the default.

## Testing

- `helm template .` — renders identically to before (fallback to
  `.Release.Namespace`, no behavior change)
- `helm template . --set namespace=custom-ns` — all resources render with
  `namespace: custom-ns`

## Backwards compatibility

Non-breaking: default behavior is unchanged when `namespace` is not set.