### PR TITLE
fix(helm): allow unmounted serviceAccountToken + initContainers empty…

### DIFF
--- a/charts/qdrant/templates/serviceaccount.yaml
+++ b/charts/qdrant/templates/serviceaccount.yaml
@@ -1,5 +1,6 @@
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "qdrant.fullname" . }}
 {{- if or .Values.serviceAccount.annotations .Values.additionalAnnotations }}

--- a/charts/qdrant/templates/statefulset.yaml
+++ b/charts/qdrant/templates/statefulset.yaml
@@ -53,9 +53,8 @@ spec:
       {{- if hasKey .Values "terminationGracePeriodSeconds" }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
+      {{- if and .Values.updateVolumeFsOwnership (not .Values.image.useUnprivilegedImage) .Values.containerSecurityContext .Values.containerSecurityContext.runAsUser }}
       initContainers:
-      {{- if and .Values.updateVolumeFsOwnership (not .Values.image.useUnprivilegedImage) }}
-      {{- if and .Values.containerSecurityContext .Values.containerSecurityContext.runAsUser }}
       - name: ensure-dir-ownership
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         command:
@@ -81,7 +80,6 @@ spec:
           {{- if and .Values.snapshotRestoration.enabled .Values.snapshotRestoration.pvcName }}
           - name: qdrant-snapshot-restoration
             mountPath: {{ .Values.snapshotRestoration.mountPath }}
-          {{- end }}
       {{- end }}
       {{- end }}
       containers:
@@ -239,6 +237,7 @@ spec:
         {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "qdrant.fullname" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       volumes:
         - name: qdrant-config
           configMap:

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -233,6 +233,7 @@ metrics:
 
 serviceAccount:
   annotations: {}
+  automountServiceAccountToken: false
 
 priorityClassName: ""
 


### PR DESCRIPTION
This PR is for allowing configuration of ServiceAccountToken value, and fixing initContainers creating an empty key

Issue here: https://github.com/qdrant/qdrant-helm/issues/506